### PR TITLE
Fix upload/download: added safe for URLs in jinja templates

### DIFF
--- a/src/firecrest/filesystem/transfer/scripts/slurm_job_downloader.sh
+++ b/src/firecrest/filesystem/transfer/scripts/slurm_job_downloader.sh
@@ -11,7 +11,7 @@ echo $(date -u) "Ingress File Transfer Job (id:${SLURM_JOB_ID})"
 echo $(date -u) "Waiting till file to tranfer is available..."
 for i in `seq 1440` 
 do 
-    status=$(curl --silent --head -o /dev/null --silent -Iw '%{http_code}' "{{ download_head_url }}")
+    status=$(curl --silent --head -o /dev/null --silent -Iw '%{http_code}' "{{ download_head_url | safe }}")
     if [[ "$status" == '200' ]]
         then
             echo $(date -u) "File to transfer found in S3 bucket"
@@ -33,7 +33,7 @@ do
                 part_file="$target_file.$part_i"
                 range_to=$(( range_from + range_length - 1 ))
 
-                http_code=$(curl --compressed --silent -D "$headers_file" --output "$part_file" --range "$range_from-$range_to" -w "%{http_code}" "{{ download_url }}")
+                http_code=$(curl --compressed --silent -D "$headers_file" --output "$part_file" --range "$range_from-$range_to" -w "%{http_code}" "{{ download_url | safe }}")
                 content_range=$(grep -i "Content-Range" "$headers_file")
                 file_length=$(echo ${content_range##*/} | tr -cd '[:digit:]')
                 content_length=$(grep -i "Content-Length" "$headers_file")

--- a/src/firecrest/filesystem/transfer/scripts/slurm_job_uploader_multipart.sh
+++ b/src/firecrest/filesystem/transfer/scripts/slurm_job_uploader_multipart.sh
@@ -255,7 +255,7 @@ completeUploadXML="<CompleteMultipartUpload xmlns=\"http://s3.amazonaws.com/doc/
 
 # Complete multipart upload
 status=$(curl -f --show-error -s -i -o /dev/null -w "%{http_code}" -d "$completeUploadXML" -X POST $complete_multipart_url)
-echo "curl -f --show-error -s -i -o /dev/null -w "%{http_code}" -d "$completeUploadXML" -X POST $complete_multipart_url"
+
 if [[ "$status" == '200' ]]
 then
     echo "[INFO] Multipart file upload successfully completed"

--- a/src/firecrest/filesystem/transfer/scripts/slurm_job_uploader_multipart.sh
+++ b/src/firecrest/filesystem/transfer/scripts/slurm_job_uploader_multipart.sh
@@ -14,7 +14,7 @@ BLOCK_SIZE=1048576
 MAX_PART_SIZE={{ F7T_MAX_PART_SIZE }}
 
 # Global parts array
-parts_url=({{ F7T_MP_PARTS_URL }})
+parts_url=({{ F7T_MP_PARTS_URL | safe }})
 
 # ----------------------------------------------------------------------------
 # UTILITY FUNCTIONS
@@ -174,7 +174,7 @@ parallel_run={{ F7T_MP_PARALLEL_RUN }}
 use_split={{ F7T_MP_USE_SPLIT }}
 num_parts={{ F7T_MP_NUM_PARTS }}
 input_file={{ F7T_MP_INPUT_FILE }}
-complete_multipart_url='{{ F7T_MP_COMPLETE_URL }}'
+complete_multipart_url='{{ F7T_MP_COMPLETE_URL | safe }}'
 
 echo "[INFO] Uploading file:$input_file into $num_parts chunks"
 
@@ -255,7 +255,7 @@ completeUploadXML="<CompleteMultipartUpload xmlns=\"http://s3.amazonaws.com/doc/
 
 # Complete multipart upload
 status=$(curl -f --show-error -s -i -o /dev/null -w "%{http_code}" -d "$completeUploadXML" -X POST $complete_multipart_url)
-
+echo "curl -f --show-error -s -i -o /dev/null -w "%{http_code}" -d "$completeUploadXML" -X POST $complete_multipart_url"
 if [[ "$status" == '200' ]]
 then
     echo "[INFO] Multipart file upload successfully completed"


### PR DESCRIPTION
The URLs were not encoded correctly (for instance quotes, &, and others).
Using `safe` filter for jinja templates ([reference](https://jinja.palletsprojects.com/en/stable/templates/#working-with-automatic-escaping)) to avoid auto-escaping of special characters.