### PR TITLE
Use BaseCommandWithTimeoutErrorHandling class for error handling

### DIFF
--- a/build/demo-launcher/src/launcher/pwd_command.py
+++ b/build/demo-launcher/src/launcher/pwd_command.py
@@ -5,14 +5,14 @@
 
 # commands
 from firecrest.filesystem.ops.commands.base_command_error_handling import (
-    BaseCommandErrorHandling,
+    BaseCommandWithTimeoutErrorHandling,
 )
 from lib.ssh_clients.ssh_client import BaseCommand
 
 UTILITIES_TIMEOUT = 5
 
 
-class PwdCommand(BaseCommand, BaseCommandErrorHandling):
+class PwdCommand(BaseCommand, BaseCommandWithTimeoutErrorHandling):
 
     def __init__(
         self,

--- a/build/demo-launcher/src/launcher/pwd_command.py
+++ b/build/demo-launcher/src/launcher/pwd_command.py
@@ -4,15 +4,12 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 # commands
-from firecrest.filesystem.ops.commands.base_command_error_handling import (
-    BaseCommandWithTimeoutErrorHandling,
+from firecrest.filesystem.ops.commands.base_command_with_timeout import (
+    BaseCommandWithTimeout,
 )
-from lib.ssh_clients.ssh_client import BaseCommand
-
-UTILITIES_TIMEOUT = 5
 
 
-class PwdCommand(BaseCommand, BaseCommandWithTimeoutErrorHandling):
+class PwdCommand(BaseCommandWithTimeout):
 
     def __init__(
         self,
@@ -20,7 +17,7 @@ class PwdCommand(BaseCommand, BaseCommandWithTimeoutErrorHandling):
         super().__init__()
 
     def get_command(self) -> str:
-        return f"timeout {UTILITIES_TIMEOUT} pwd"
+        return f"{super().get_command()} pwd"
 
     def parse_output(self, stdout: str, stderr: str, exit_status: int = 0):
 

--- a/build/demo-launcher/src/launcher/sinfo_command.py
+++ b/build/demo-launcher/src/launcher/sinfo_command.py
@@ -4,15 +4,14 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 # commands
-from firecrest.filesystem.ops.commands.base_command_error_handling import (
-    BaseCommandWithTimeoutErrorHandling,
+
+
+from firecrest.filesystem.ops.commands.base_command_with_timeout import (
+    BaseCommandWithTimeout,
 )
-from lib.ssh_clients.ssh_client import BaseCommand
-
-UTILITIES_TIMEOUT = 5
 
 
-class SinfoVersionCommand(BaseCommand, BaseCommandWithTimeoutErrorHandling):
+class SinfoVersionCommand(BaseCommandWithTimeout):
 
     def __init__(
         self,
@@ -20,7 +19,7 @@ class SinfoVersionCommand(BaseCommand, BaseCommandWithTimeoutErrorHandling):
         super().__init__()
 
     def get_command(self) -> str:
-        return f"timeout {UTILITIES_TIMEOUT} sinfo -V"
+        return f"{super().get_command()} sinfo -V"
 
     def parse_output(self, stdout: str, stderr: str, exit_status: int = 0):
 

--- a/build/demo-launcher/src/launcher/sinfo_command.py
+++ b/build/demo-launcher/src/launcher/sinfo_command.py
@@ -5,14 +5,14 @@
 
 # commands
 from firecrest.filesystem.ops.commands.base_command_error_handling import (
-    BaseCommandErrorHandling,
+    BaseCommandWithTimeoutErrorHandling,
 )
 from lib.ssh_clients.ssh_client import BaseCommand
 
 UTILITIES_TIMEOUT = 5
 
 
-class SinfoVersionCommand(BaseCommand, BaseCommandErrorHandling):
+class SinfoVersionCommand(BaseCommand, BaseCommandWithTimeoutErrorHandling):
 
     def __init__(
         self,

--- a/src/firecrest/filesystem/ops/commands/base64_command.py
+++ b/src/firecrest/filesystem/ops/commands/base64_command.py
@@ -3,15 +3,13 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
-from firecrest.filesystem.ops.commands.base_command_error_handling import (
-    BaseCommandWithTimeoutErrorHandling,
+
+from firecrest.filesystem.ops.commands.base_command_with_timeout import (
+    BaseCommandWithTimeout,
 )
-from lib.ssh_clients.ssh_client import BaseCommand
-
-UTILITIES_TIMEOUT = 5
 
 
-class Base64Command(BaseCommand, BaseCommandWithTimeoutErrorHandling):
+class Base64Command(BaseCommandWithTimeout):
 
     def __init__(self, path: str | None = None, decode: bool = False) -> None:
         super().__init__()
@@ -22,8 +20,8 @@ class Base64Command(BaseCommand, BaseCommandWithTimeoutErrorHandling):
         self,
     ) -> str:
         if self.decode:
-            return f"timeout {UTILITIES_TIMEOUT} base64 -d > '{self.path}'"
-        return f"timeout {UTILITIES_TIMEOUT} base64 --wrap=0 -- '{self.path}'"
+            return f"{super().get_command()} base64 -d > '{self.path}'"
+        return f"{super().get_command()} base64 --wrap=0 -- '{self.path}'"
 
     def parse_output(self, stdout: str, stderr: str, exit_status: int):
         if exit_status != 0:

--- a/src/firecrest/filesystem/ops/commands/base64_command.py
+++ b/src/firecrest/filesystem/ops/commands/base64_command.py
@@ -4,14 +4,14 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from firecrest.filesystem.ops.commands.base_command_error_handling import (
-    BaseCommandErrorHandling,
+    BaseCommandWithTimeoutErrorHandling,
 )
 from lib.ssh_clients.ssh_client import BaseCommand
 
 UTILITIES_TIMEOUT = 5
 
 
-class Base64Command(BaseCommand, BaseCommandErrorHandling):
+class Base64Command(BaseCommand, BaseCommandWithTimeoutErrorHandling):
 
     def __init__(self, path: str | None = None, decode: bool = False) -> None:
         super().__init__()

--- a/src/firecrest/filesystem/ops/commands/base_command_error_handling.py
+++ b/src/firecrest/filesystem/ops/commands/base_command_error_handling.py
@@ -68,7 +68,7 @@ class BaseCommandWithTimeoutErrorHandling(BaseCommandErrorHandling):
         if len(stderr) > 0:
             error_mess += f" and error message:{stderr.strip()}"
 
-        if self.timeout_prepended and exit_status == 124:
+        if exit_status == 124:
             raise HTTPException(
                 status_code=status.HTTP_408_REQUEST_TIMEOUT, detail=error_mess
             )

--- a/src/firecrest/filesystem/ops/commands/base_command_error_handling.py
+++ b/src/firecrest/filesystem/ops/commands/base_command_error_handling.py
@@ -27,18 +27,12 @@ class CommandExecutionError(HTTPException):
 
 
 class BaseCommandErrorHandling:
-    timeout_prepended = False
 
     def error_handling(self, stderr: str, exit_status: int):
 
         error_mess = f"Remote process failed with exit status:{exit_status}"
         if len(stderr) > 0:
             error_mess += f" and error message:{stderr.strip()}"
-
-        if self.timeout_prepended and exit_status == 124:
-            raise HTTPException(
-                status_code=status.HTTP_408_REQUEST_TIMEOUT, detail=error_mess
-            )
 
         if "No such file or directory" in stderr:
             raise HTTPException(
@@ -67,4 +61,16 @@ class BaseCommandErrorHandling:
 
 
 class BaseCommandWithTimeoutErrorHandling(BaseCommandErrorHandling):
-    timeout_prepended = True
+
+    def error_handling(self, stderr: str, exit_status: int):
+
+        error_mess = f"Remote process failed with exit status:{exit_status}"
+        if len(stderr) > 0:
+            error_mess += f" and error message:{stderr.strip()}"
+
+        if self.timeout_prepended and exit_status == 124:
+            raise HTTPException(
+                status_code=status.HTTP_408_REQUEST_TIMEOUT, detail=error_mess
+            )
+
+        super().error_handling(stderr, exit_status)

--- a/src/firecrest/filesystem/ops/commands/base_command_error_handling.py
+++ b/src/firecrest/filesystem/ops/commands/base_command_error_handling.py
@@ -58,19 +58,3 @@ class BaseCommandErrorHandling:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=error_mess
         )
-
-
-class BaseCommandWithTimeoutErrorHandling(BaseCommandErrorHandling):
-
-    def error_handling(self, stderr: str, exit_status: int):
-
-        error_mess = f"Remote process failed with exit status:{exit_status}"
-        if len(stderr) > 0:
-            error_mess += f" and error message:{stderr.strip()}"
-
-        if exit_status == 124:
-            raise HTTPException(
-                status_code=status.HTTP_408_REQUEST_TIMEOUT, detail=error_mess
-            )
-
-        super().error_handling(stderr, exit_status)

--- a/src/firecrest/filesystem/ops/commands/base_command_error_handling.py
+++ b/src/firecrest/filesystem/ops/commands/base_command_error_handling.py
@@ -27,6 +27,7 @@ class CommandExecutionError(HTTPException):
 
 
 class BaseCommandErrorHandling:
+    timeout_prepended = False
 
     def error_handling(self, stderr: str, exit_status: int):
 
@@ -34,7 +35,7 @@ class BaseCommandErrorHandling:
         if len(stderr) > 0:
             error_mess += f" and error message:{stderr.strip()}"
 
-        if exit_status == 124:
+        if self.timeout_prepended and exit_status == 124:
             raise HTTPException(
                 status_code=status.HTTP_408_REQUEST_TIMEOUT, detail=error_mess
             )
@@ -63,3 +64,7 @@ class BaseCommandErrorHandling:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=error_mess
         )
+
+
+class BaseCommandWithTimeoutErrorHandling(BaseCommandErrorHandling):
+    timeout_prepended = True

--- a/src/firecrest/filesystem/ops/commands/base_command_with_timeout.py
+++ b/src/firecrest/filesystem/ops/commands/base_command_with_timeout.py
@@ -1,0 +1,38 @@
+from abc import abstractmethod
+from fastapi import HTTPException, status
+from firecrest.filesystem.ops.commands.base_command_error_handling import (
+    BaseCommandErrorHandling,
+)
+from lib.ssh_clients.ssh_client import BaseCommand
+
+
+UTILITIES_TIMEOUT = 5
+
+
+class BaseCommandWithTimeoutErrorHandling(BaseCommandErrorHandling):
+
+    def error_handling(self, stderr: str, exit_status: int):
+
+        error_mess = f"Remote process failed with exit status:{exit_status}"
+        if len(stderr) > 0:
+            error_mess += f" and error message:{stderr.strip()}"
+
+        if exit_status == 124:
+            raise HTTPException(
+                status_code=status.HTTP_408_REQUEST_TIMEOUT, detail=error_mess
+            )
+
+        super().error_handling(stderr, exit_status)
+
+
+class BaseCommandWithTimeout(BaseCommand, BaseCommandWithTimeoutErrorHandling):
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    def get_command(self) -> str:
+        return f"timeout {UTILITIES_TIMEOUT}"
+
+    @abstractmethod
+    def parse_output(self, stdout: str, stderr: str, exit_status: int):
+        pass

--- a/src/firecrest/filesystem/ops/commands/checksum_command.py
+++ b/src/firecrest/filesystem/ops/commands/checksum_command.py
@@ -6,7 +6,7 @@
 # commands
 from fastapi import status, HTTPException
 from firecrest.filesystem.ops.commands.base_command_error_handling import (
-    BaseCommandErrorHandling,
+    BaseCommandWithTimeoutErrorHandling,
 )
 from lib.ssh_clients.ssh_client import BaseCommand
 
@@ -22,7 +22,7 @@ available_algorithms = {
 }
 
 
-class ChecksumCommand(BaseCommand, BaseCommandErrorHandling):
+class ChecksumCommand(BaseCommand, BaseCommandWithTimeoutErrorHandling):
 
     def __init__(self, target_path: str = None, algorithm: str = "SHA256") -> None:
         super().__init__()

--- a/src/firecrest/filesystem/ops/commands/checksum_command.py
+++ b/src/firecrest/filesystem/ops/commands/checksum_command.py
@@ -5,13 +5,12 @@
 
 # commands
 from fastapi import status, HTTPException
-from firecrest.filesystem.ops.commands.base_command_error_handling import (
-    BaseCommandWithTimeoutErrorHandling,
+from firecrest.filesystem.ops.commands.base_command_with_timeout import (
+    BaseCommandWithTimeout,
 )
-from lib.ssh_clients.ssh_client import BaseCommand
+
 
 ID = 0
-UTILITIES_TIMEOUT = 5
 
 # Available checksum commands
 available_algorithms = {
@@ -22,7 +21,7 @@ available_algorithms = {
 }
 
 
-class ChecksumCommand(BaseCommand, BaseCommandWithTimeoutErrorHandling):
+class ChecksumCommand(BaseCommandWithTimeout):
 
     def __init__(self, target_path: str = None, algorithm: str = "SHA256") -> None:
         super().__init__()
@@ -30,7 +29,7 @@ class ChecksumCommand(BaseCommand, BaseCommandWithTimeoutErrorHandling):
         self.target_path = target_path
 
     def get_command(self) -> str:
-        return f"timeout {UTILITIES_TIMEOUT} {available_algorithms[self.selected_algorithm]} -- '{self.target_path}'"
+        return f"{super().get_command()} {available_algorithms[self.selected_algorithm]} -- '{self.target_path}'"
 
     def parse_output(self, stdout: str, stderr: str, exit_status: int = 0):
         # Example of sha256sum output

--- a/src/firecrest/filesystem/ops/commands/chmod_command.py
+++ b/src/firecrest/filesystem/ops/commands/chmod_command.py
@@ -25,4 +25,4 @@ class ChmodCommand(BaseCommandWithTimeout):
         if exit_status != 0:
             super().error_handling(stderr, exit_status)
 
-        return self.ls_command().parse_output(stdout, stderr, exit_status)
+        return self.ls_command.parse_output(stdout, stderr, exit_status)

--- a/src/firecrest/filesystem/ops/commands/chmod_command.py
+++ b/src/firecrest/filesystem/ops/commands/chmod_command.py
@@ -4,28 +4,25 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 # commands
-from firecrest.filesystem.ops.commands.base_command_error_handling import (
-    BaseCommandWithTimeoutErrorHandling,
+from firecrest.filesystem.ops.commands.base_command_with_timeout import (
+    BaseCommandWithTimeout,
 )
 from firecrest.filesystem.ops.commands.ls_base_command import LsBaseCommand
 
-UTILITIES_TIMEOUT = 5
 
-
-class ChmodCommand(LsBaseCommand, BaseCommandWithTimeoutErrorHandling):
+class ChmodCommand(BaseCommandWithTimeout):
 
     def __init__(self, target_path: str = None, mode: str = None) -> None:
-        super().__init__(target_path, no_recursion=True)
         self.target_path = target_path
         self.mode = mode
+        self.ls_command = LsBaseCommand(target_path, no_recursion=True)
 
     def get_command(self) -> str:
-        ls_command = super().get_command()
-        return f"timeout {UTILITIES_TIMEOUT} chmod -v '{self.mode}' -- '{self.target_path}' && {ls_command}"
+        return f"{super().get_command()} chmod -v '{self.mode}' -- '{self.target_path}' && {self.ls_command.get_command()}"
 
     def parse_output(self, stdout: str, stderr: str, exit_status: int = 0):
 
         if exit_status != 0:
             super().error_handling(stderr, exit_status)
 
-        return super().parse_output(stdout, stderr, exit_status)
+        return self.ls_command().parse_output(stdout, stderr, exit_status)

--- a/src/firecrest/filesystem/ops/commands/chmod_command.py
+++ b/src/firecrest/filesystem/ops/commands/chmod_command.py
@@ -5,14 +5,14 @@
 
 # commands
 from firecrest.filesystem.ops.commands.base_command_error_handling import (
-    BaseCommandErrorHandling,
+    BaseCommandWithTimeoutErrorHandling,
 )
 from firecrest.filesystem.ops.commands.ls_base_command import LsBaseCommand
 
 UTILITIES_TIMEOUT = 5
 
 
-class ChmodCommand(LsBaseCommand, BaseCommandErrorHandling):
+class ChmodCommand(LsBaseCommand, BaseCommandWithTimeoutErrorHandling):
 
     def __init__(self, target_path: str = None, mode: str = None) -> None:
         super().__init__(target_path, no_recursion=True)

--- a/src/firecrest/filesystem/ops/commands/chown_command.py
+++ b/src/firecrest/filesystem/ops/commands/chown_command.py
@@ -4,30 +4,28 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 # commands
-from firecrest.filesystem.ops.commands.base_command_error_handling import (
-    BaseCommandWithTimeoutErrorHandling,
+from firecrest.filesystem.ops.commands.base_command_with_timeout import (
+    BaseCommandWithTimeout,
 )
 from firecrest.filesystem.ops.commands.ls_base_command import LsBaseCommand
 
-UTILITIES_TIMEOUT = 5
 
-
-class ChownCommand(LsBaseCommand, BaseCommandWithTimeoutErrorHandling):
+class ChownCommand(BaseCommandWithTimeout):
 
     def __init__(
         self, target_path: str = None, owner: str = None, group: str = None
     ) -> None:
-        super().__init__(target_path, no_recursion=True)
         self.target_path = target_path
         self.owner = owner
         self.group = group
+        self.ls_command = LsBaseCommand(target_path, no_recursion=True)
 
     def get_command(self) -> str:
-        ls_command = super().get_command()
-        return f"timeout {UTILITIES_TIMEOUT} chown -v '{self.owner}':'{self.group}' -- '{self.target_path}' && {ls_command}"
+
+        return f"{super().get_command()} chown -v '{self.owner}':'{self.group}' -- '{self.target_path}' && {self.ls_command.get_command()}"
 
     def parse_output(self, stdout: str, stderr: str, exit_status: int = 0):
         if exit_status != 0:
             super().error_handling(stderr, exit_status)
 
-        return super().parse_output(stdout, stderr, exit_status)
+        return self.ls_command().parse_output(stdout, stderr, exit_status)

--- a/src/firecrest/filesystem/ops/commands/chown_command.py
+++ b/src/firecrest/filesystem/ops/commands/chown_command.py
@@ -28,4 +28,4 @@ class ChownCommand(BaseCommandWithTimeout):
         if exit_status != 0:
             super().error_handling(stderr, exit_status)
 
-        return self.ls_command().parse_output(stdout, stderr, exit_status)
+        return self.ls_command.parse_output(stdout, stderr, exit_status)

--- a/src/firecrest/filesystem/ops/commands/chown_command.py
+++ b/src/firecrest/filesystem/ops/commands/chown_command.py
@@ -5,14 +5,14 @@
 
 # commands
 from firecrest.filesystem.ops.commands.base_command_error_handling import (
-    BaseCommandErrorHandling,
+    BaseCommandWithTimeoutErrorHandling,
 )
 from firecrest.filesystem.ops.commands.ls_base_command import LsBaseCommand
 
 UTILITIES_TIMEOUT = 5
 
 
-class ChownCommand(LsBaseCommand, BaseCommandErrorHandling):
+class ChownCommand(LsBaseCommand, BaseCommandWithTimeoutErrorHandling):
 
     def __init__(
         self, target_path: str = None, owner: str = None, group: str = None

--- a/src/firecrest/filesystem/ops/commands/file_command.py
+++ b/src/firecrest/filesystem/ops/commands/file_command.py
@@ -5,14 +5,14 @@
 
 # commands
 from firecrest.filesystem.ops.commands.base_command_error_handling import (
-    BaseCommandErrorHandling,
+    BaseCommandWithTimeoutErrorHandling,
 )
 from lib.ssh_clients.ssh_client import BaseCommand
 
 UTILITIES_TIMEOUT = 5
 
 
-class FileCommand(BaseCommand, BaseCommandErrorHandling):
+class FileCommand(BaseCommand, BaseCommandWithTimeoutErrorHandling):
 
     def __init__(
         self,

--- a/src/firecrest/filesystem/ops/commands/file_command.py
+++ b/src/firecrest/filesystem/ops/commands/file_command.py
@@ -4,15 +4,14 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 # commands
-from firecrest.filesystem.ops.commands.base_command_error_handling import (
-    BaseCommandWithTimeoutErrorHandling,
+
+
+from firecrest.filesystem.ops.commands.base_command_with_timeout import (
+    BaseCommandWithTimeout,
 )
-from lib.ssh_clients.ssh_client import BaseCommand
-
-UTILITIES_TIMEOUT = 5
 
 
-class FileCommand(BaseCommand, BaseCommandWithTimeoutErrorHandling):
+class FileCommand(BaseCommandWithTimeout):
 
     def __init__(
         self,
@@ -22,7 +21,7 @@ class FileCommand(BaseCommand, BaseCommandWithTimeoutErrorHandling):
         self.target_path = target_path
 
     def get_command(self) -> str:
-        return f"timeout {UTILITIES_TIMEOUT} file -b -- '{self.target_path}'"
+        return f"{super().get_command()} file -b -- '{self.target_path}'"
 
     def parse_output(self, stdout: str, stderr: str, exit_status: int = 0):
 

--- a/src/firecrest/filesystem/ops/commands/head_command.py
+++ b/src/firecrest/filesystem/ops/commands/head_command.py
@@ -3,16 +3,16 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
-from firecrest.filesystem.ops.commands.base_command_error_handling import (
-    BaseCommandWithTimeoutErrorHandling,
-)
-from lib.ssh_clients.ssh_client import BaseCommand
 
-UTILITIES_TIMEOUT = 5
+from firecrest.filesystem.ops.commands.base_command_with_timeout import (
+    BaseCommandWithTimeout,
+)
+
+
 UTILITIES_MAX_FILE = 5 * 1024 * 1024  # 5MB
 
 
-class HeadCommand(BaseCommand, BaseCommandWithTimeoutErrorHandling):
+class HeadCommand(BaseCommandWithTimeout):
 
     def __init__(
         self,
@@ -41,7 +41,7 @@ class HeadCommand(BaseCommand, BaseCommandWithTimeoutErrorHandling):
             else:
                 options += f"--lines='{self.lines}' "
 
-        return f"timeout {UTILITIES_TIMEOUT} head {options}-- '{self.target_path}'"
+        return f"{super().get_command()} head {options}-- '{self.target_path}'"
 
     def parse_output(self, stdout: str, stderr: str, exit_status: int = 0):
         if exit_status != 0:

--- a/src/firecrest/filesystem/ops/commands/head_command.py
+++ b/src/firecrest/filesystem/ops/commands/head_command.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from firecrest.filesystem.ops.commands.base_command_error_handling import (
-    BaseCommandErrorHandling,
+    BaseCommandWithTimeoutErrorHandling,
 )
 from lib.ssh_clients.ssh_client import BaseCommand
 
@@ -12,7 +12,7 @@ UTILITIES_TIMEOUT = 5
 UTILITIES_MAX_FILE = 5 * 1024 * 1024  # 5MB
 
 
-class HeadCommand(BaseCommand, BaseCommandErrorHandling):
+class HeadCommand(BaseCommand, BaseCommandWithTimeoutErrorHandling):
 
     def __init__(
         self,

--- a/src/firecrest/filesystem/ops/commands/ls_base_command.py
+++ b/src/firecrest/filesystem/ops/commands/ls_base_command.py
@@ -8,17 +8,13 @@ import shlex
 from fastapi import HTTPException, status
 
 # commands
-from firecrest.filesystem.ops.commands.base_command_error_handling import (
-    BaseCommandErrorHandling,
+from firecrest.filesystem.ops.commands.base_command_with_timeout import (
+    BaseCommandWithTimeout,
 )
 from firecrest.filesystem.ops.models import File
-from lib.ssh_clients.ssh_client import BaseCommand
 
 
-UTILITIES_TIMEOUT = 5
-
-
-class LsBaseCommand(BaseCommand, BaseCommandErrorHandling):
+class LsBaseCommand(BaseCommandWithTimeout):
 
     def __init__(
         self,
@@ -59,7 +55,7 @@ class LsBaseCommand(BaseCommand, BaseCommandErrorHandling):
         if self.dereference:
             options += "-L "
 
-        return f"ls " f"{options}" f"-- '{self.target_path}'"
+        return f"{super().get_command()} ls " f"{options}" f"-- '{self.target_path}'"
 
     def parse_output(self, stdout: str, stderr: str, exit_status: int = 0):
         # Example of ls output

--- a/src/firecrest/filesystem/ops/commands/ls_command.py
+++ b/src/firecrest/filesystem/ops/commands/ls_command.py
@@ -4,13 +4,16 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 # commands
+from firecrest.filesystem.ops.commands.base_command_error_handling import (
+    BaseCommandWithTimeoutErrorHandling,
+)
 from firecrest.filesystem.ops.commands.ls_base_command import LsBaseCommand
 
 
 UTILITIES_TIMEOUT = 5
 
 
-class LsCommand(LsBaseCommand):
+class LsCommand(LsBaseCommand, BaseCommandWithTimeoutErrorHandling):
 
     def __init__(
         self,

--- a/src/firecrest/filesystem/ops/commands/ls_command.py
+++ b/src/firecrest/filesystem/ops/commands/ls_command.py
@@ -4,16 +4,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 # commands
-from firecrest.filesystem.ops.commands.base_command_error_handling import (
-    BaseCommandWithTimeoutErrorHandling,
-)
 from firecrest.filesystem.ops.commands.ls_base_command import LsBaseCommand
 
 
-UTILITIES_TIMEOUT = 5
-
-
-class LsCommand(LsBaseCommand, BaseCommandWithTimeoutErrorHandling):
+class LsCommand(LsBaseCommand):
 
     def __init__(
         self,
@@ -29,5 +23,4 @@ class LsCommand(LsBaseCommand, BaseCommandWithTimeoutErrorHandling):
         )
 
     def get_command(self) -> str:
-        ls_cmd = super().get_command()
-        return f"timeout {UTILITIES_TIMEOUT} " f"{ls_cmd}"
+        return super().get_command()

--- a/src/firecrest/filesystem/ops/commands/mkdir_command.py
+++ b/src/firecrest/filesystem/ops/commands/mkdir_command.py
@@ -5,7 +5,7 @@
 
 # commands
 from firecrest.filesystem.ops.commands.base_command_error_handling import (
-    BaseCommandErrorHandling,
+    BaseCommandWithTimeoutErrorHandling,
 )
 from firecrest.filesystem.ops.commands.ls_base_command import LsBaseCommand
 
@@ -13,7 +13,7 @@ from firecrest.filesystem.ops.commands.ls_base_command import LsBaseCommand
 UTILITIES_TIMEOUT = 5
 
 
-class MkdirCommand(LsBaseCommand, BaseCommandErrorHandling):
+class MkdirCommand(LsBaseCommand, BaseCommandWithTimeoutErrorHandling):
 
     def __init__(self, target_path: str = None, parent: bool = False) -> None:
         super().__init__(target_path, no_recursion=True)

--- a/src/firecrest/filesystem/ops/commands/mkdir_command.py
+++ b/src/firecrest/filesystem/ops/commands/mkdir_command.py
@@ -4,33 +4,31 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 # commands
-from firecrest.filesystem.ops.commands.base_command_error_handling import (
-    BaseCommandWithTimeoutErrorHandling,
+
+
+from firecrest.filesystem.ops.commands.base_command_with_timeout import (
+    BaseCommandWithTimeout,
 )
 from firecrest.filesystem.ops.commands.ls_base_command import LsBaseCommand
 
 
-UTILITIES_TIMEOUT = 5
-
-
-class MkdirCommand(LsBaseCommand, BaseCommandWithTimeoutErrorHandling):
+class MkdirCommand(BaseCommandWithTimeout):
 
     def __init__(self, target_path: str = None, parent: bool = False) -> None:
-        super().__init__(target_path, no_recursion=True)
         self.target_path = target_path
         self.parent = parent
+        self.ls_command = LsBaseCommand(target_path, no_recursion=True)
 
     def get_command(self) -> str:
-        ls_command = super().get_command()
         options = ""
         if self.parent:
             # if set shows entrys starting with . (not including . and/or .. dirs)
             options = "-p "
-        return f"timeout {UTILITIES_TIMEOUT} mkdir {options} -- '{self.target_path}' && {ls_command}"
+        return f"{super().get_command()} mkdir {options} -- '{self.target_path}' && {self.ls_command.get_command()}"
 
     def parse_output(self, stdout: str, stderr: str, exit_status: int = 0):
 
         if exit_status != 0:
             super().error_handling(stderr, exit_status)
 
-        return super().parse_output(stdout, stderr, exit_status)
+        return self.ls_command.parse_output(stdout, stderr, exit_status)

--- a/src/firecrest/filesystem/ops/commands/rm_command.py
+++ b/src/firecrest/filesystem/ops/commands/rm_command.py
@@ -5,14 +5,14 @@
 
 # commands
 from firecrest.filesystem.ops.commands.base_command_error_handling import (
-    BaseCommandErrorHandling,
+    BaseCommandWithTimeoutErrorHandling,
 )
 from lib.ssh_clients.ssh_client import BaseCommand
 
 UTILITIES_TIMEOUT = 5
 
 
-class RmCommand(BaseCommand, BaseCommandErrorHandling):
+class RmCommand(BaseCommand, BaseCommandWithTimeoutErrorHandling):
 
     def __init__(self, target_path: str = None) -> None:
         super().__init__()

--- a/src/firecrest/filesystem/ops/commands/rm_command.py
+++ b/src/firecrest/filesystem/ops/commands/rm_command.py
@@ -4,22 +4,23 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 # commands
-from firecrest.filesystem.ops.commands.base_command_error_handling import (
-    BaseCommandWithTimeoutErrorHandling,
+
+
+from firecrest.filesystem.ops.commands.base_command_with_timeout import (
+    BaseCommandWithTimeout,
 )
-from lib.ssh_clients.ssh_client import BaseCommand
-
-UTILITIES_TIMEOUT = 5
 
 
-class RmCommand(BaseCommand, BaseCommandWithTimeoutErrorHandling):
+class RmCommand(BaseCommandWithTimeout):
 
     def __init__(self, target_path: str = None) -> None:
         super().__init__()
         self.target_path = target_path
 
     def get_command(self) -> str:
-        return f"timeout {UTILITIES_TIMEOUT} rm -r --interactive=never -- '{self.target_path}'"
+        return (
+            f"{super().get_command()} rm -r --interactive=never -- '{self.target_path}'"
+        )
 
     def parse_output(self, stdout: str, stderr: str, exit_status: int = 0):
         if exit_status != 0:

--- a/src/firecrest/filesystem/ops/commands/stat_command.py
+++ b/src/firecrest/filesystem/ops/commands/stat_command.py
@@ -5,7 +5,7 @@
 
 # commands
 from firecrest.filesystem.ops.commands.base_command_error_handling import (
-    BaseCommandErrorHandling,
+    BaseCommandWithTimeoutErrorHandling,
 )
 from lib.ssh_clients.ssh_client import BaseCommand
 
@@ -13,7 +13,7 @@ ID = 0
 UTILITIES_TIMEOUT = 5
 
 
-class StatCommand(BaseCommand, BaseCommandErrorHandling):
+class StatCommand(BaseCommand, BaseCommandWithTimeoutErrorHandling):
 
     def __init__(self, target_path: str = None, dereference: bool = False) -> None:
         super().__init__()

--- a/src/firecrest/filesystem/ops/commands/stat_command.py
+++ b/src/firecrest/filesystem/ops/commands/stat_command.py
@@ -4,16 +4,15 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 # commands
-from firecrest.filesystem.ops.commands.base_command_error_handling import (
-    BaseCommandWithTimeoutErrorHandling,
+from firecrest.filesystem.ops.commands.base_command_with_timeout import (
+    BaseCommandWithTimeout,
 )
-from lib.ssh_clients.ssh_client import BaseCommand
+
 
 ID = 0
-UTILITIES_TIMEOUT = 5
 
 
-class StatCommand(BaseCommand, BaseCommandWithTimeoutErrorHandling):
+class StatCommand(BaseCommandWithTimeout):
 
     def __init__(self, target_path: str = None, dereference: bool = False) -> None:
         super().__init__()
@@ -26,7 +25,7 @@ class StatCommand(BaseCommand, BaseCommandWithTimeoutErrorHandling):
         deref = ""
         if self.dereference:
             deref = "--dereference"
-        return f"timeout {UTILITIES_TIMEOUT} stat {deref} -c '%f %i %d %h %u %g %s %X %Y %Z' -- '{self.target_path}'"
+        return f"{super().get_command()} stat {deref} -c '%f %i %d %h %u %g %s %X %Y %Z' -- '{self.target_path}'"
 
     def parse_output(self, stdout: str, stderr: str, exit_status: int = 0):
         if exit_status != 0:

--- a/src/firecrest/filesystem/ops/commands/symlink_command.py
+++ b/src/firecrest/filesystem/ops/commands/symlink_command.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from firecrest.filesystem.ops.commands.base_command_error_handling import (
-    BaseCommandErrorHandling,
+    BaseCommandWithTimeoutErrorHandling,
 )
 from firecrest.filesystem.ops.commands.ls_base_command import LsBaseCommand
 
@@ -12,7 +12,7 @@ from firecrest.filesystem.ops.commands.ls_base_command import LsBaseCommand
 UTILITIES_TIMEOUT = 5
 
 
-class SymlinkCommand(LsBaseCommand, BaseCommandErrorHandling):
+class SymlinkCommand(LsBaseCommand, BaseCommandWithTimeoutErrorHandling):
 
     def __init__(self, target_path: str = None, link_path: str = None) -> None:
         super().__init__(target_path, no_recursion=True)

--- a/src/firecrest/filesystem/ops/commands/symlink_command.py
+++ b/src/firecrest/filesystem/ops/commands/symlink_command.py
@@ -3,28 +3,26 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
-from firecrest.filesystem.ops.commands.base_command_error_handling import (
-    BaseCommandWithTimeoutErrorHandling,
+
+from firecrest.filesystem.ops.commands.base_command_with_timeout import (
+    BaseCommandWithTimeout,
 )
 from firecrest.filesystem.ops.commands.ls_base_command import LsBaseCommand
 
 
-UTILITIES_TIMEOUT = 5
-
-
-class SymlinkCommand(LsBaseCommand, BaseCommandWithTimeoutErrorHandling):
+class SymlinkCommand(BaseCommandWithTimeout):
 
     def __init__(self, target_path: str = None, link_path: str = None) -> None:
-        super().__init__(target_path, no_recursion=True)
         self.target_path = target_path
         self.link_path = link_path
+        self.ls_command = LsBaseCommand(target_path, no_recursion=True)
 
     def get_command(self) -> str:
-        ls_command = super().get_command()
-        return f"timeout {UTILITIES_TIMEOUT} ln -s -- '{self.target_path}' '{self.link_path}' && {ls_command}"
+
+        return f"{super().get_command()} ln -s -- '{self.target_path}' '{self.link_path}' && {self.ls_command.get_command()}"
 
     def parse_output(self, stdout: str, stderr: str, exit_status: int = 0):
         if exit_status != 0:
             super().error_handling(stderr, exit_status)
 
-        return super().parse_output(stdout, stderr, exit_status)
+        return self.ls_command.parse_output(stdout, stderr, exit_status)

--- a/src/firecrest/filesystem/ops/commands/tail_command.py
+++ b/src/firecrest/filesystem/ops/commands/tail_command.py
@@ -3,16 +3,14 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
-from firecrest.filesystem.ops.commands.base_command_error_handling import (
-    BaseCommandWithTimeoutErrorHandling,
+from firecrest.filesystem.ops.commands.base_command_with_timeout import (
+    BaseCommandWithTimeout,
 )
-from lib.ssh_clients.ssh_client import BaseCommand
 
-UTILITIES_TIMEOUT = 5
 UTILITIES_MAX_FILE = 5 * 1024 * 1024  # 5MB
 
 
-class TailCommand(BaseCommand, BaseCommandWithTimeoutErrorHandling):
+class TailCommand(BaseCommandWithTimeout):
 
     def __init__(
         self,
@@ -43,7 +41,7 @@ class TailCommand(BaseCommand, BaseCommandWithTimeoutErrorHandling):
             else:
                 options += f"--lines='{self.lines}' "
 
-        return f"timeout {UTILITIES_TIMEOUT} tail {options}-- '{self.target_path}'"
+        return f"{super().get_command()} tail {options}-- '{self.target_path}'"
 
     def parse_output(self, stdout: str, stderr: str, exit_status: int):
         if exit_status != 0:

--- a/src/firecrest/filesystem/ops/commands/tail_command.py
+++ b/src/firecrest/filesystem/ops/commands/tail_command.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from firecrest.filesystem.ops.commands.base_command_error_handling import (
-    BaseCommandErrorHandling,
+    BaseCommandWithTimeoutErrorHandling,
 )
 from lib.ssh_clients.ssh_client import BaseCommand
 
@@ -12,7 +12,7 @@ UTILITIES_TIMEOUT = 5
 UTILITIES_MAX_FILE = 5 * 1024 * 1024  # 5MB
 
 
-class TailCommand(BaseCommand, BaseCommandErrorHandling):
+class TailCommand(BaseCommand, BaseCommandWithTimeoutErrorHandling):
 
     def __init__(
         self,

--- a/src/firecrest/filesystem/ops/commands/tar_command.py
+++ b/src/firecrest/filesystem/ops/commands/tar_command.py
@@ -6,14 +6,14 @@
 from enum import Enum
 import os
 from firecrest.filesystem.ops.commands.base_command_error_handling import (
-    BaseCommandErrorHandling,
+    BaseCommandWithTimeoutErrorHandling,
 )
 from lib.ssh_clients.ssh_client import BaseCommand
 
 UTILITIES_TIMEOUT = 5
 
 
-class TarCommand(BaseCommand, BaseCommandErrorHandling):
+class TarCommand(BaseCommand, BaseCommandWithTimeoutErrorHandling):
 
     class Operation(str, Enum):
         compress = "compress"
@@ -56,7 +56,6 @@ class TarCommand(BaseCommand, BaseCommandErrorHandling):
             return f"timeout {UTILITIES_TIMEOUT} bash -c \"cd {source_dir}; timeout {UTILITIES_TIMEOUT} find . -type f -regex '{self.match_pattern}' -print0 | tar {options} -czvf '{self.target_path}' --null --files-from - \""
 
         return f"timeout {UTILITIES_TIMEOUT} tar {options} -czvf '{self.target_path}' -C '{source_dir}' '{source_file}'"
-
 
     def get_extract_command(self) -> str:
 

--- a/src/firecrest/filesystem/ops/commands/tar_command.py
+++ b/src/firecrest/filesystem/ops/commands/tar_command.py
@@ -5,15 +5,13 @@
 
 from enum import Enum
 import os
-from firecrest.filesystem.ops.commands.base_command_error_handling import (
-    BaseCommandWithTimeoutErrorHandling,
+
+from firecrest.filesystem.ops.commands.base_command_with_timeout import (
+    BaseCommandWithTimeout,
 )
-from lib.ssh_clients.ssh_client import BaseCommand
-
-UTILITIES_TIMEOUT = 5
 
 
-class TarCommand(BaseCommand, BaseCommandWithTimeoutErrorHandling):
+class TarCommand(BaseCommandWithTimeout):
 
     class Operation(str, Enum):
         compress = "compress"
@@ -53,13 +51,13 @@ class TarCommand(BaseCommand, BaseCommandWithTimeoutErrorHandling):
         source_file = os.path.basename(self.source_path)
 
         if self.match_pattern:
-            return f"timeout {UTILITIES_TIMEOUT} bash -c \"cd {source_dir}; timeout {UTILITIES_TIMEOUT} find . -type f -regex '{self.match_pattern}' -print0 | tar {options} -czvf '{self.target_path}' --null --files-from - \""
+            return f"{super().get_command()} bash -c \"cd {source_dir}; {super().get_command()} find . -type f -regex '{self.match_pattern}' -print0 | tar {options} -czvf '{self.target_path}' --null --files-from - \""
 
-        return f"timeout {UTILITIES_TIMEOUT} tar {options} -czvf '{self.target_path}' -C '{source_dir}' '{source_file}'"
+        return f"{super().get_command()} tar {options} -czvf '{self.target_path}' -C '{source_dir}' '{source_file}'"
 
     def get_extract_command(self) -> str:
 
-        return f"timeout {UTILITIES_TIMEOUT} tar -xzf '{self.source_path}' -C '{self.target_path}'"
+        return f"{super().get_command()} tar -xzf '{self.source_path}' -C '{self.target_path}'"
 
     def parse_output(self, stdout: str, stderr: str, exit_status: int):
         if exit_status != 0:

--- a/src/firecrest/filesystem/ops/commands/view_command.py
+++ b/src/firecrest/filesystem/ops/commands/view_command.py
@@ -4,23 +4,26 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 # commands
-from firecrest.filesystem.ops.commands.base_command_error_handling import (
-    BaseCommandWithTimeoutErrorHandling,
-)
-from lib.ssh_clients.ssh_client import BaseCommand
 
-UTILITIES_TIMEOUT = 5
+
+from firecrest.filesystem.ops.commands.base_command_with_timeout import (
+    BaseCommandWithTimeout,
+)
+
+
 SIZE_LIMIT = 5 * 1024 * 1024
 
 
-class ViewCommand(BaseCommand, BaseCommandWithTimeoutErrorHandling):
+class ViewCommand(BaseCommandWithTimeout):
 
     def __init__(self, target_path: str = None) -> None:
         super().__init__()
         self.target_path = target_path
 
     def get_command(self) -> str:
-        return f"timeout {UTILITIES_TIMEOUT} head --bytes {SIZE_LIMIT} -- '{self.target_path}'"
+        return (
+            f"{super().get_command()} head --bytes {SIZE_LIMIT} -- '{self.target_path}'"
+        )
 
     def parse_output(self, stdout: str, stderr: str, exit_status: int):
         if exit_status != 0:

--- a/src/firecrest/filesystem/ops/commands/view_command.py
+++ b/src/firecrest/filesystem/ops/commands/view_command.py
@@ -5,7 +5,7 @@
 
 # commands
 from firecrest.filesystem.ops.commands.base_command_error_handling import (
-    BaseCommandErrorHandling,
+    BaseCommandWithTimeoutErrorHandling,
 )
 from lib.ssh_clients.ssh_client import BaseCommand
 
@@ -13,7 +13,7 @@ UTILITIES_TIMEOUT = 5
 SIZE_LIMIT = 5 * 1024 * 1024
 
 
-class ViewCommand(BaseCommand, BaseCommandErrorHandling):
+class ViewCommand(BaseCommand, BaseCommandWithTimeoutErrorHandling):
 
     def __init__(self, target_path: str = None) -> None:
         super().__init__()

--- a/src/firecrest/status/commands/id_command.py
+++ b/src/firecrest/status/commands/id_command.py
@@ -3,16 +3,15 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
-from firecrest.filesystem.ops.commands.base_command_error_handling import (
-    BaseCommandWithTimeoutErrorHandling,
+from firecrest.filesystem.ops.commands.base_command_with_timeout import (
+    BaseCommandWithTimeout,
 )
-from lib.ssh_clients.ssh_client import BaseCommand
 
-UTILITIES_TIMEOUT = 5
+
 UTILITIES_MAX_FILE = 5 * 1024 * 1024  # 5MB
 
 
-class IdCommand(BaseCommand, BaseCommandWithTimeoutErrorHandling):
+class IdCommand(BaseCommandWithTimeout):
 
     def __init__(
         self,
@@ -22,7 +21,7 @@ class IdCommand(BaseCommand, BaseCommandWithTimeoutErrorHandling):
     def get_command(
         self,
     ) -> str:
-        return f"timeout {UTILITIES_TIMEOUT} id"
+        return f"{super().get_command()} id"
 
     def parse_output(self, stdout: str, stderr: str, exit_status: int):
         if exit_status != 0:

--- a/src/firecrest/status/commands/id_command.py
+++ b/src/firecrest/status/commands/id_command.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from firecrest.filesystem.ops.commands.base_command_error_handling import (
-    BaseCommandErrorHandling,
+    BaseCommandWithTimeoutErrorHandling,
 )
 from lib.ssh_clients.ssh_client import BaseCommand
 
@@ -12,7 +12,7 @@ UTILITIES_TIMEOUT = 5
 UTILITIES_MAX_FILE = 5 * 1024 * 1024  # 5MB
 
 
-class IdCommand(BaseCommand, BaseCommandErrorHandling):
+class IdCommand(BaseCommand, BaseCommandWithTimeoutErrorHandling):
 
     def __init__(
         self,


### PR DESCRIPTION
Continuing the discussion from https://github.com/eth-cscs/firecrest-v2/pull/24 :
I created another class in the end. The only command we don't use the timeout for is `true`.