### PR TITLE
Added create release note workflow

### DIFF
--- a/.github/workflows/create-release-notes.yml
+++ b/.github/workflows/create-release-notes.yml
@@ -1,0 +1,30 @@
+name: Create Release Notes
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-release-notes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Extract Release Notes from CHANGELOG.md
+        id: extract_notes
+        run: |
+          VERSION=${{ github.event.release.tag_name }}
+          echo "Version selected: $VERSION"
+
+          # Extract content for the $VERSION in the form "## [$VERSION]"
+          sed -n "/^## \[$VERSION\]/,/^## \[/p" CHANGELOG.md | sed '1d;$d' > release_notes.txt
+
+      - name: Update Release Notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release edit ${{ github.event.release.tag_name }} --notes-file release_notes.txt
+    


### PR DESCRIPTION
Creates (it updates) the release note text from an already `published` Release with the content of the `CHANGELOG.md` file searching for the string "## [$VERSION]" where VERSION=2.X.Y.