### PR TITLE
Fix docker dev environment for windows hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,15 +78,21 @@ client: firecrest-test-client
 secret: wZVHVIEd9dkJDh9hMKc6DTvkqXxnDttk
 ```
 
-To optain an access token you can either use the Authorize button in the [swagger documentation](http://localhost:8000/docs) or directly access Keycloack's Oauth2 token end-point:  http://localhost:8080/auth/realms/kcrealm/protocol/openid-connect/token
-
+To optain an access token you can either use the Authorize button in the [swagger documentation](http://localhost:8000/docs) or directly access Keycloack's Oauth2 token end-point:
+```bash
+CLIENT_ID="<client>"
+CLIENT_SECRET="<secret>"
+curl -X POST http://localhost:8080/auth/realms/kcrealm/protocol/openid-connect/token \
+     -d "grant_type=client_credentials" -d "client_id=$CLIENT_ID" -d "client_secret=$CLIENT_SECRET" \
+     -H "Content-Type: application/x-www-form-urlencoded" -H "Accept: */*"
+```
 
 # Development
 
 The repository comes with VS Code settings (.vscode) to facilitate running and debugging a local instance of FirecREST v2.
 All necessary VS Code extensions will be listed as recommended and are defined in .vscode/extensions.json.
 
-## Set-up Python Virtual environement
+## Set-up Python Virtual environment
 
 Install python3.12 on your machine.
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ client: firecrest-test-client
 secret: wZVHVIEd9dkJDh9hMKc6DTvkqXxnDttk
 ```
 
-To optain an access token you can either use the Authorize button in the [swagger documentation](http://localhost:8000/docs) or directly access Keycloack's Oauth2 token end-point:
+To obtain an access token you can either use the Authorize button in the [swagger documentation](http://localhost:8000/docs) or directly access Keycloack's Oauth2 token end-point:
 ```bash
 CLIENT_ID="<client>"
 CLIENT_SECRET="<secret>"

--- a/build/docker/slurm-cluster/Dockerfile
+++ b/build/docker/slurm-cluster/Dockerfile
@@ -16,7 +16,8 @@ RUN apt update -y \
     wget \
     curl \
     python3 \
-    supervisor
+    supervisor \
+    dos2unix
 
 # Install Slurm
 RUN apt install -y slurmd slurmdbd slurmctld slurmrestd mpich
@@ -34,6 +35,7 @@ RUN chmod 644 /etc/slurm/*.conf && chmod 600 /etc/slurm/slurmdbd.conf  && chown 
 # Setup services
 ADD ./build/docker/slurm-cluster/supervisord.conf /etc/supervisord.conf
 RUN chmod 755 /*.sh
+RUN dos2unix /*.sh
 
 # Setup users
 RUN useradd -m -s /bin/bash --no-user-group --gid users  fireuser  && echo 'fireuser:fireuser'       | chpasswd


### PR DESCRIPTION
This fixes the issue when deploying dev environment containers in a Windows host.

```
2025-03-14 16:10:30 2025-03-14 15:10:30,599 WARN exited: mariadb (exit status 127; not expected)
2025-03-14 16:10:30 2025-03-14 15:10:30,600 WARN exited: update-jwt-certs (exit status 127; not expected)
2025-03-14 16:10:30 2025-03-14 15:10:30,600 WARN exited: slurmctld (exit status 127; not expected)
2025-03-14 16:10:30 2025-03-14 15:10:30,604 WARN exited: slurmdbd (exit status 127; not expected)
2025-03-14 16:10:30 2025-03-14 15:10:30,625 WARN exited: slurmrestd (exit status 127; not expected)
```

The error was related to `supervisord` in `slurm` container not being able to start services such as `mariadb`, `slurmd`, etc, due to the encoding injected on the Ubuntu container was formatted with the format from the Windows host.

This is solved by converting the `*.sh` files that `supervisord` executes using `dos2unix` tool.

@iB0nes could you test this in your host and verify this works? 