### PR TITLE
Added case insensitive check for ETag in downloads

### DIFF
--- a/src/firecrest/filesystem/transfer/scripts/slurm_job_uploader_multipart.sh
+++ b/src/firecrest/filesystem/transfer/scripts/slurm_job_uploader_multipart.sh
@@ -102,7 +102,7 @@ function job_upload() {
     echo "[INFO] Uploading part $part_id..."
 
     # Upload data with curl and extract ETag
-    if ! data=$(curl -s -D - --upload-file "$part_file" "$part_url" | grep "ETag");
+    if ! data=$(curl -s -D - --upload-file "$part_file" "$part_url" | grep -i "^ETag: ");
     then
         # Non-blocking error notification
         # (.result file not generated and evaluated later, part file still in transfer directory)


### PR DESCRIPTION
The S3 output in some systems is not `ETag` but could be `etag`, like in the example below. This PR fixes this.
```
HTTP/1.1 100 CONTINUE

HTTP/1.1 200 OK
content-length: 0
etag: "e5*******************************"
accept-ranges: bytes
x-amz-expiration: expiry-date="Sat, 29 Mar 2025 00:00:00 GMT", rule-id="ExpireObjects"
x-amz-request-id: tx00000ccccccc40d67e49a67-0067d94e33-6e0e80b-naret-zone
date: Tue, 18 Mar 2025 10:43:07 GMT
set-cookie: SERVERID=naret-rgw06; path=/
```