### PR TITLE
Fixed demo launcher login node check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Demo launcher ssh loging node checks socket connection instead executing a ping
+- Demo launcher ssh login node checks socket connection instead executing a ping
 - Removed deprecated keycloak configuration from docker dev environment
 
 ## [2.2.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.2] - OPEN
 
-## [2.2.1] - OPEN
+### Added
+
+
+### Changed
+
+### Fixed
+
+- Demo launcher ssh loging node checks socket connection instead executing a ping
+- Removed deprecated keycloak configuration from docker dev environment
+
+## [2.2.1]
 
 ### Added
 - FirecREST Web UI has been added to the demo image.

--- a/build/docker/keycloak/keycloak.env
+++ b/build/docker/keycloak/keycloak.env
@@ -9,10 +9,8 @@ KC_DB=dev-file
 KC_REALM_NAME=kcrealm
 KC_REALM_DISPLAY_NAME=kcrealm
 # Hostname configuration
-KC_HOSTNAME=localhost
-KC_HOSTNAME_PORT=8080
-KC_HOSTNAME_STRICT_BACKCHANNEL=false
-KC_HOSTNAME_STRICT_HTTPS=false
+
+KC_HOSTNAME=http://localhost:8080/auth
 # Http configuration
 KC_HTTP_ENABLED=true
 # Enable health check


### PR DESCRIPTION
- Demo launcher ssh login node checks socket connection instead executing a ping
- Removed deprecated keycloak configuration from docker dev environment