### PR TITLE
Fix SSH authentication in docker compose environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,11 +158,9 @@ To add the username claim to the token:
 To ssh into the Slurm Dummy Cluster you can use the fireuser
 
 ```console
-
-ssh-keygen -p -s build/environment/keys/fireuser-key -n fireuser -I fireuser -f user-key-cert.pub build/environment/keys/fireuser.pub
-chmod 0400 build/environment/keys/fireuser.pub
-ssh -i build/environment/keys/fireuser.pub fireuser@localhost -p 2222
-
+chmod 400 build/environment/keys/fireuser-key
+ssh-keygen -s build/environment/keys/fireuser-key -n fireuser -I fireuser build/environment/keys/fireuser.pub
+ssh -i build/environment/keys/fireuser-key -o CertificateFile=build/environment/keys/fireuser-cert.pub fireuser@localhost -p 2222
 ```
 
 

--- a/build/docker/slurm-cluster/Dockerfile
+++ b/build/docker/slurm-cluster/Dockerfile
@@ -43,7 +43,7 @@ RUN groupadd service-accounts
 RUN useradd -m -s /bin/bash --no-user-group --gid service-accounts firesrv    && echo 'firesrv:sfiresrv'      | chpasswd
 
 ADD --chown=fireuser:users ./build/environment/keys/fireuser.pub /home/fireuser/.ssh/authorized_keys
-ADD --chown=firesrv:users ./build/environment/keys/firesrv.pub /home/firesrv/.ssh/authorized_keys
+ADD --chown=firesrv:service-accounts ./build/environment/keys/firesrv.pub /home/firesrv/.ssh/authorized_keys
 
 # Setup SSH keys
 RUN chmod 0755 /var/run/sshd

--- a/build/docker/slurm-cluster/ssh/sshd_config_base
+++ b/build/docker/slurm-cluster/ssh/sshd_config_base
@@ -100,6 +100,9 @@ Subsystem       sftp    /usr/libexec/openssh/sftp-server
 
 PubkeyAcceptedKeyTypes ssh-rsa,ssh-rsa-cert-v01@openssh.com,ssh-ed25519-cert-v01@openssh.com,ssh-ed25519
 PermitRootLogin  yes
+
+# Trusted CA key during image build (see Dockerfile)
+TrustedUserCAKeys /etc/ssh/ca-key.pub
 #DenyGroups root bin admin sys
 
 MaxAuthTries 1000


### PR DESCRIPTION
Hello to the Firecrest-v2 team,

Thank you for the clear instructions and great testing environment you provide in this project. I ran into a couple of issues while launching the Docker Compose environment and this PR provides the fixes I think appropriate. 

### SSH key pair auth for `firesrv` fails
After deploying the environment, the `/status/systems` endpoint shows the following:
```
        {
          "serviceType": "ssh",
          "lastChecked": "2025-03-27T13:14:20.545403Z",
          "latency": 0.39400219917297363,
          "healthy": false,
          "message": "Permission denied for user firesrv on host 192.168.240.2"
        },
        {
          "serviceType": "filesystem",
          "lastChecked": "2025-03-27T13:14:20.563274Z",
          "latency": 0.28319644927978516,
          "healthy": false,
          "message": "Permission denied for user firesrv on host 192.168.240.2",
          "path": "/home"
        }
```
SSH logs in the luster show the issue is bad ownership of the `authorized_keys` file. I fixed this issue by setting the proper group ownership to the file in `Dokerfile`.

### SSH Certificate auth to the cluster does not work
 The sshd configuration does not include the CA key into the `TrustedUserCAKeys` . Additionally, the commands in `README.md` do not work as expected (at least by me). I fixed the sshd config and provided a set of commands should do the trick directly.

( I'm new to firecrest, so if my fixes make no sense, please let me know)