### PR TITLE
Add link to .NET solution for files transfer examples

### DIFF
--- a/docs/user_guide/file_transfer_dotnet/README.md
+++ b/docs/user_guide/file_transfer_dotnet/README.md
@@ -64,7 +64,7 @@ An example `.credentials_demo` file, configured for accessing the Docker demo en
 !!! example "Inner structure of `.credentials` file."
     ```json
     {
-        "Url": "http://localhost:8080/auth/realms/kcrealm/protocol/openid-connect/token"
+        "Url": "http://localhost:8080/auth/realms/kcrealm/protocol/openid-connect/token",
         "ClientID": "firecrest-test-client",
         "ClientSecret": "wxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxk"
     }

--- a/docs/user_guide/file_transfer_dotnet/README.md
+++ b/docs/user_guide/file_transfer_dotnet/README.md
@@ -1,5 +1,7 @@
 # FirecREST File Transfer with C# .NET
 ## General description
+The .NET solution file (`data_transfer_dotnet.sln`) is available by cloning this repository and accessing to the pat [docs/user_guide/file_transfer_dotnet](.).
+
 This .NET solution provides examples demonstrating how to connect to FirecREST and transfer files using C# via different API endpoints. The implementation follows a fully `async` approach.
 
 The Examples do not requires parameters. You may be able to build them and run the generated executable. All of them, by default, target the [Docker-Compose demo environment](../../getting_started/README.md#trying-firecrest-in-a-containerised-environment).

--- a/docs/user_guide/file_transfer_dotnet/README.md
+++ b/docs/user_guide/file_transfer_dotnet/README.md
@@ -1,6 +1,12 @@
 # FirecREST File Transfer with C# .NET
 ## General description
-The .NET solution file (`data_transfer_dotnet.sln`) is available by cloning this repository and accessing to the pat [docs/user_guide/file_transfer_dotnet](.).
+The .NET solution file (`data_transfer_dotnet.sln`) is available by cloning this repository and accessing to the path [docs/user_guide/file_transfer_dotnet](.).
+
+!!! example "Getting the .NET solution."
+    ```
+    git clone https://github.com/eth-cscs/firecrest-v2.git
+    cd firecrest-v2/docs/user_guide/file_transfer_dotnet
+    ```
 
 This .NET solution provides examples demonstrating how to connect to FirecREST and transfer files using C# via different API endpoints. The implementation follows a fully `async` approach.
 


### PR DESCRIPTION
Added to the docs the explicit path to the .NET solution for the files transfer examples