### PR TITLE
Added env variable UVICORN_LOG_CONFIG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Environment variable `UVICORN_LOG_CONFIG` to enable [Uvicorn log configuration](https://www.uvicorn.org/settings/#logging) file path (analog to `--log-config`)
+
 ### Changed
 
 ### Fixed

--- a/build/helm/firecrest-api/templates/firecrest-api-depl.yaml
+++ b/build/helm/firecrest-api/templates/firecrest-api-depl.yaml
@@ -33,6 +33,10 @@ spec:
               value: {{ .Chart.AppVersion }}
             - name: LOGGING_LEVEL
               value: {{ .Values.loggingLevel }}
+            {{- if .Values.logConfig }}
+            - name: UVICORN_LOG_CONFIG
+              values: .Values.logConfig
+            {{- end }}
           volumeMounts:
           - name: firecrest-configs-volume
             mountPath: /app/configs/


### PR DESCRIPTION
This variable is needed to enable the log configuration passed in `logConfig` value on the helm chart.

It's only set if the `logConfig` var is set.