### PR TITLE
Add `allusers` parameter to `GET /compute/jobs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Query parameter `allusers` in `GET /compute/jobs` to show scheduler jobs from all users
+- Query parameter `allusers` in `GET /compute/jobs` to show all visible jobs for the user in the scheduler
 - Environment variable `UVICORN_LOG_CONFIG` to enable [Uvicorn log configuration](https://www.uvicorn.org/settings/#logging) file path (analog to `--log-config`)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Query parameter `allusers` in `GET /compute/jobs` to show scheduler jobs from all users
 - Environment variable `UVICORN_LOG_CONFIG` to enable [Uvicorn log configuration](https://www.uvicorn.org/settings/#logging) file path (analog to `--log-config`)
 
 ### Changed

--- a/src/firecrest/compute/router.py
+++ b/src/firecrest/compute/router.py
@@ -79,7 +79,7 @@ async def get_jobs(
         Path(alias="system_name", description="Target system"),
         Depends(SchedulerClientDependency()),
     ],
-    allusers: Annotated[bool, Query(description="Show all users' jobs")] = False
+    allusers: Annotated[bool, Query(description="If set to `true` returns all jobs visible by the current user, otherwise only the current user owned jobs")] = False
 ) -> Any:
     username = ApiAuthHelper.get_auth().username
     access_token = ApiAuthHelper.get_access_token()

--- a/src/firecrest/compute/router.py
+++ b/src/firecrest/compute/router.py
@@ -3,7 +3,7 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
-from fastapi import status, Path, HTTPException, Depends
+from fastapi import status, Path, HTTPException, Depends, Query
 from typing import Any, Annotated
 
 # helpers
@@ -79,10 +79,15 @@ async def get_jobs(
         Path(alias="system_name", description="Target system"),
         Depends(SchedulerClientDependency()),
     ],
+    allusers: Annotated[bool, Query(description="Show all users' jobs")] = False
 ) -> Any:
     username = ApiAuthHelper.get_auth().username
     access_token = ApiAuthHelper.get_access_token()
-    jobs = await scheduler_client.get_jobs(username=username, jwt_token=access_token)
+    jobs = await scheduler_client.get_jobs(
+        username=username,
+        jwt_token=access_token,
+        allusers=allusers
+    )
     return {"jobs": jobs}
 
 
@@ -99,12 +104,14 @@ async def get_job(
         SchedulerBaseClient,
         Path(alias="system_name", description="Target system"),
         Depends(SchedulerClientDependency()),
-    ],
+    ]    
 ) -> Any:
     username = ApiAuthHelper.get_auth().username
     access_token = ApiAuthHelper.get_access_token()
     jobs = await scheduler_client.get_job(
-        job_id=job_id, username=username, jwt_token=access_token
+        job_id=job_id,
+        username=username,
+        jwt_token=access_token
     )
     if jobs is None:
         raise HTTPException(

--- a/src/lib/scheduler_clients/scheduler_base_client.py
+++ b/src/lib/scheduler_clients/scheduler_base_client.py
@@ -44,7 +44,8 @@ class SchedulerBaseClient(ABC):
         self,
         job_id: str,
         username: str,
-        jwt_token: str
+        jwt_token: str,
+        allusers: bool = True
     ) -> List[JobModel]:
         pass
 

--- a/src/lib/scheduler_clients/scheduler_base_client.py
+++ b/src/lib/scheduler_clients/scheduler_base_client.py
@@ -41,7 +41,10 @@ class SchedulerBaseClient(ABC):
     @abstractmethod
     # Note: returns multiple jobs to deal with job_id duplicates (see Slurm doc)
     async def get_job(
-        self, job_id: str, username: str, jwt_token: str
+        self,
+        job_id: str,
+        username: str,
+        jwt_token: str
     ) -> List[JobModel]:
         pass
 
@@ -53,7 +56,12 @@ class SchedulerBaseClient(ABC):
         pass
 
     @abstractmethod
-    async def get_jobs(self, username: str, jwt_token: str) -> List[JobModel] | None:
+    async def get_jobs(
+        self,
+        username: str,
+        jwt_token: str,
+        allusers: bool = False
+    ) -> List[JobModel] | None:
         pass
 
     @abstractmethod

--- a/src/lib/scheduler_clients/slurm/cli_commands/sacct_base.py
+++ b/src/lib/scheduler_clients/slurm/cli_commands/sacct_base.py
@@ -11,14 +11,20 @@ from lib.ssh_clients.ssh_client import BaseCommand
 
 class SacctCommandBase(BaseCommand):
 
-    def __init__(self, username: str = None, job_ids: List[str] = None) -> None:
+    def __init__(
+            self,
+            username: str = None,
+            job_ids: List[str] = None,
+            allusers: bool = False) -> None:
         super().__init__()
         self.username = username
+        self.allusers = allusers
         self.job_ids = job_ids
 
     def get_command(self) -> str:
         cmd = ["sacct"]
-        cmd += [f"--user={self.username}"]
+        if self.allusers:
+            cmd += ["--allusers"]
         if self.job_ids:
             str_job_ids = ",".join(self.job_ids)
             cmd += [f"--jobs='{str_job_ids}'"]

--- a/src/lib/scheduler_clients/slurm/slurm_base_client.py
+++ b/src/lib/scheduler_clients/slurm/slurm_base_client.py
@@ -52,7 +52,7 @@ class SlurmBaseClient(SchedulerBaseClient):
         pass
 
     @abstractmethod
-    async def get_jobs(self, username: str, jwt_token: str) -> List[SlurmJob] | None:
+    async def get_jobs(self, username: str, jwt_token: str, show_all_users: bool = False) -> List[SlurmJob] | None:
         pass
 
     @abstractmethod

--- a/src/lib/scheduler_clients/slurm/slurm_base_client.py
+++ b/src/lib/scheduler_clients/slurm/slurm_base_client.py
@@ -52,7 +52,7 @@ class SlurmBaseClient(SchedulerBaseClient):
         pass
 
     @abstractmethod
-    async def get_jobs(self, username: str, jwt_token: str, show_all_users: bool = False) -> List[SlurmJob] | None:
+    async def get_jobs(self, username: str, jwt_token: str, allusers: bool = False) -> List[SlurmJob] | None:
         pass
 
     @abstractmethod

--- a/src/lib/scheduler_clients/slurm/slurm_base_client.py
+++ b/src/lib/scheduler_clients/slurm/slurm_base_client.py
@@ -41,7 +41,11 @@ class SlurmBaseClient(SchedulerBaseClient):
     @abstractmethod
     # Note: returns multiple jobs to deal with job_id duplicates (see Slurm doc)
     async def get_job(
-        self, job_id: str, username: str, jwt_token: str
+        self,
+        job_id: str,
+        username: str,
+        jwt_token: str,
+        allusers: bool = True
     ) -> List[SlurmJob]:
         pass
 

--- a/src/lib/scheduler_clients/slurm/slurm_cli_client.py
+++ b/src/lib/scheduler_clients/slurm/slurm_cli_client.py
@@ -87,7 +87,7 @@ class SlurmCliClient(SlurmBaseClient):
         job_id: str | None,
         username: str,
         jwt_token: str,
-        allusers: bool = False
+        allusers: bool = True
     ) -> List[SlurmJob] | None:
         sacct = SacctCommand(
             username,

--- a/src/lib/scheduler_clients/slurm/slurm_cli_client.py
+++ b/src/lib/scheduler_clients/slurm/slurm_cli_client.py
@@ -83,9 +83,17 @@ class SlurmCliClient(SlurmBaseClient):
         return await self.__executed_ssh_cmd(username, jwt_token, srun)
 
     async def get_job(
-        self, job_id: str | None, username: str, jwt_token: str
+        self,
+        job_id: str | None,
+        username: str,
+        jwt_token: str,
+        allusers: bool = False
     ) -> List[SlurmJob] | None:
-        sacct = SacctCommand(username, [job_id] if job_id else None)
+        sacct = SacctCommand(
+            username,
+            [job_id] if job_id else None,
+            allusers
+            )
         return await self.__executed_ssh_cmd(username, jwt_token, sacct)
 
     async def get_job_metadata(
@@ -140,8 +148,15 @@ class SlurmCliClient(SlurmBaseClient):
 
         return jobs
 
-    async def get_jobs(self, username: str, jwt_token: str) -> List[SlurmJob] | None:
-        return await self.get_job(job_id=None, username=username, jwt_token=jwt_token)
+    async def get_jobs(self,
+                       username: str,
+                       jwt_token: str,
+                       allusers: bool = False
+                       ) -> List[SlurmJob] | None:
+        return await self.get_job(job_id=None,
+                                  username=username,
+                                  jwt_token=jwt_token,
+                                  allusers=allusers)
 
     async def cancel_job(self, job_id: str, username: str, jwt_token: str) -> bool:
         scancel = ScancelCommand(username, job_id)

--- a/src/lib/scheduler_clients/slurm/slurm_client.py
+++ b/src/lib/scheduler_clients/slurm/slurm_client.py
@@ -71,7 +71,7 @@ class SlurmClient(SlurmBaseClient):
             job_id: str | None,
             username: str,
             jwt_token: str,
-            allusers: bool = False
+            allusers: bool = True
             ) -> List[SlurmJob] | None:
         return await self.slurm_default_client.get_job(job_id,
                                                        username,

--- a/src/lib/scheduler_clients/slurm/slurm_client.py
+++ b/src/lib/scheduler_clients/slurm/slurm_client.py
@@ -67,14 +67,26 @@ class SlurmClient(SlurmBaseClient):
                                                               jwt_token)
 
     async def get_job(
-            self, job_id: str | None, username: str, jwt_token: str
+            self,
+            job_id: str | None,
+            username: str,
+            jwt_token: str,
+            allusers: bool = False
             ) -> List[SlurmJob] | None:
-        return await self.slurm_default_client.get_job(job_id, username,
-                                                       jwt_token)
+        return await self.slurm_default_client.get_job(job_id,
+                                                       username,
+                                                       jwt_token,
+                                                       allusers)
 
-    async def get_jobs(self, username: str, jwt_token: str
-                       ) -> List[SlurmJob] | None:
-        return await self.slurm_default_client.get_jobs(username, jwt_token)
+    async def get_jobs(
+            self,
+            username: str,
+            jwt_token: str,
+            allusers: bool = False
+            ) -> List[SlurmJob] | None:
+        return await self.slurm_default_client.get_jobs(username,
+                                                        jwt_token,
+                                                        allusers)
 
     async def get_job_metadata(
             self, job_id: str, username: str, jwt_token: str

--- a/src/lib/scheduler_clients/slurm/slurm_rest_client.py
+++ b/src/lib/scheduler_clients/slurm/slurm_rest_client.py
@@ -140,7 +140,11 @@ class SlurmRestClient(SlurmBaseClient):
         pass
 
     async def get_job(
-        self, job_id: str, username: str, jwt_token: str
+        self,
+        job_id: str,
+        username: str,
+        jwt_token: str,
+        allusers: bool = False   
     ) -> List[SlurmJob] | None:
         client = await self.get_aiohttp_client()
         timeout = aiohttp.ClientTimeout(total=self.timeout)
@@ -157,7 +161,12 @@ class SlurmRestClient(SlurmBaseClient):
             job_result = await response.json()
 
             # Note: starting from API version v0.0.39 this filter can be set as query param
-            jobs = list(filter(lambda job: job["user"] == username, job_result["jobs"]))
+            jobs = list(
+                filter(
+                    lambda job: allusers or job["user"] == username,
+                    job_result["jobs"]
+                    )
+                )
             if len(jobs) == 0:
                 return None
 
@@ -169,7 +178,12 @@ class SlurmRestClient(SlurmBaseClient):
         # Until version 4.05.1 slurmdb/job end-point does not provide stdout & stderr information
         raise NotImplementedError("This method is not supported by the Slurm REST API")
 
-    async def get_jobs(self, username: str, jwt_token: str) -> List[SlurmJob] | None:
+    async def get_jobs(
+            self,
+            username: str,
+            jwt_token: str,
+            allusers: bool = False
+            ) -> List[SlurmJob] | None:
         client = await self.get_aiohttp_client()
         timeout = aiohttp.ClientTimeout(total=self.timeout)
         headers = _slurm_headers(username, jwt_token)
@@ -185,7 +199,12 @@ class SlurmRestClient(SlurmBaseClient):
             job_result = await response.json()
 
             # Note: starting from API version v0.0.39 this filter can be set as query param
-            jobs = list(filter(lambda job: job["user"] == username, job_result["jobs"]))
+            jobs = list(
+                filter(
+                    lambda job: allusers or job["user"] == username,
+                    job_result["jobs"]
+                    )
+                )
             if len(jobs) == 0:
                 return None
 

--- a/src/lib/scheduler_clients/slurm/slurm_rest_client.py
+++ b/src/lib/scheduler_clients/slurm/slurm_rest_client.py
@@ -144,7 +144,7 @@ class SlurmRestClient(SlurmBaseClient):
         job_id: str,
         username: str,
         jwt_token: str,
-        allusers: bool = False   
+        allusers: bool = True   
     ) -> List[SlurmJob] | None:
         client = await self.get_aiohttp_client()
         timeout = aiohttp.ClientTimeout(total=self.timeout)

--- a/tests/compute_slurm_ssh_test.py
+++ b/tests/compute_slurm_ssh_test.py
@@ -26,6 +26,12 @@ def mocked_ssh_sacct_output():
 
 
 @pytest.fixture(scope="module")
+def mocked_ssh_sacct_allusers_output():
+    output_file = impresources.files(mocked_ssh_outputs) / "ssh_sacct_allusers_command.json"
+    with output_file.open("rb") as output:
+        return json.load(output)
+
+@pytest.fixture(scope="module")
 def mocked_ssh_sacct_script_output():
     output_file = (
         impresources.files(mocked_ssh_outputs) / "ssh_sacct_batch_script_command.json"
@@ -105,6 +111,22 @@ async def test_get_job(
 
         assert response.json()["jobs"][0]["status"]["exitCode"] == 0
         assert response.json()["jobs"][1]["status"]["exitCode"] is None
+
+
+async def test_get_jobs_allusers(
+    client, ssh_client, mocked_ssh_sacct_allusers_output, slurm_cluster_with_ssh_config
+):
+    async with ssh_client.mocked_output([MockedCommand(**mocked_ssh_sacct_allusers_output)]):
+        response = client.get(
+            "/compute/{cluster_name}/jobs?allusers=true".format(
+                cluster_name=slurm_cluster_with_ssh_config.name
+            )
+        )
+        assert response.status_code == 200
+        assert response.json() is not None
+
+        assert response.json()["jobs"][0]["user"] == "fireuser"
+        assert response.json()["jobs"][1]["user"] == "firesrv"
 
 
 async def test_get_job_metadata(

--- a/tests/compute_slurm_ssh_test.py
+++ b/tests/compute_slurm_ssh_test.py
@@ -109,8 +109,7 @@ async def test_get_job(
         assert response.status_code == 200
         assert response.json() is not None
 
-        assert response.json()["jobs"][0]["status"]["exitCode"] == 0
-        assert response.json()["jobs"][1]["status"]["exitCode"] is None
+        assert response.json()["jobs"][0]["status"]["exitCode"] == 0        
 
 
 async def test_get_jobs_allusers(

--- a/tests/mocked_api_responses/slurm_get_allusers_jobs.json
+++ b/tests/mocked_api_responses/slurm_get_allusers_jobs.json
@@ -1,0 +1,747 @@
+{
+    "meta": {
+        "plugin": {
+            "type": "openapi/dbv0.0.38",
+            "name": "Slurm OpenAPI DB v0.0.38"
+        },
+        "Slurm": {
+            "version": {
+                "major": 22,
+                "micro": 5,
+                "minor": 5
+            },
+            "release": "22.05.5"
+        }
+    },
+    "errors": [],
+    "jobs": [
+        {
+            "account": "staff",
+            "comment": {
+                "administrator": "",
+                "job": "",
+                "system": ""
+            },
+            "allocation_nodes": 1,
+            "array": {
+                "job_id": 0,
+                "limits": {
+                    "max": {
+                        "running": {
+                        "tasks": 0
+                        }
+                    }
+                },
+                "task_id": {
+                    "set": false,
+                    "infinite": false,
+                    "number": 0
+                },
+                "task": ""
+            },
+            "association": {
+                "account": "staff",
+                "cluster": "cluster",
+                "partition": "",
+                "user": "fireuser",
+                "id": 6
+            },
+            "block": "",
+            "cluster": "cluster",
+            "constraints": "",
+            "container": "",
+            "derived_exit_code": {
+                "status": [
+                    "SUCCESS"
+                ],
+                "return_code": {
+                    "set": true,
+                    "infinite": false,
+                    "number": 0
+                },
+                "signal": {
+                    "id": {
+                        "set": false,
+                        "infinite": false,
+                        "number": 0
+                    },
+                    "name": ""
+                }
+            },
+            "time": {
+                "elapsed": 100,
+                "eligible": 1748943245,
+                "end": 1748943346,
+                "planned": {
+                    "set": true,
+                    "infinite": false,
+                    "number": 1
+                },
+                "start": 1748943246,
+                "submission": 1748943245,
+                "suspended": 0,
+                "system": {
+                    "seconds": 0,
+                    "microseconds": 0
+                },
+                "limit": {
+                    "set": true,
+                    "infinite": false,
+                    "number": 7200
+                },
+                "total": {
+                    "seconds": 0,
+                    "microseconds": 0
+                },
+                "user": {
+                    "seconds": 0,
+                    "microseconds": 0
+                }
+            },
+            "exit_code": {
+                "status": [
+                    "SUCCESS"
+                ],
+                "return_code": {
+                    "set": true,
+                    "infinite": false,
+                    "number": 0
+                },
+                "signal": {
+                    "id": {
+                        "set": false,
+                        "infinite": false,
+                        "number": 0
+                    },
+                    "name": ""
+                }
+            },
+            "extra": "",
+            "failed_node": "",
+            "flags": [
+                "STARTED_ON_SCHEDULE",
+                "START_RECEIVED"
+            ],
+            "group": "users",
+            "het": {
+                "job_id": 0,
+                "job_offset": {
+                    "set": false,
+                    "infinite": false,
+                    "number": 0
+                }
+            },
+            "job_id": 1,
+            "name": "SbatchTest",
+            "licenses": "",
+            "mcs": {
+                "label": ""
+            },
+            "nodes": "localhost",
+            "partition": "part01",
+            "hold": false,
+            "priority": {
+                "set": true,
+                "infinite": false,
+                "number": 1
+            },
+            "qos": "normal",
+            "qosreq": "",
+            "required": {
+                "CPUs": 1,
+                "memory_per_cpu": {
+                    "set": false,
+                    "infinite": false,
+                    "number": 0
+                },
+                "memory_per_node": {
+                    "set": true,
+                    "infinite": false,
+                    "number": 0
+                }
+            },
+            "kill_request_user": "",
+            "restart_cnt": 0,
+            "reservation": {
+                "id": 0,
+                "name": ""
+            },
+            "script": "",
+            "stdin_expanded": "/dev/null",
+            "stdout_expanded": "/home/fireuser/job.out",
+            "stderr_expanded": "/home/fireuser/job.err",
+            "stdout": "/home/fireuser/job.out",
+            "stderr": "/home/fireuser/job.err",
+            "stdin": "/dev/null",
+            "state": {
+                "current": [
+                    "COMPLETED"
+                ],
+                "reason": "None"
+            },
+            "steps": [
+                {
+                    "time": {
+                        "elapsed": 100,
+                        "end": {
+                            "set": true,
+                            "infinite": false,
+                            "number": 1748943346
+                        },
+                        "start": {
+                            "set": true,
+                            "infinite": false,
+                            "number": 1748943246
+                        },
+                        "suspended": 0,
+                        "system": {
+                            "seconds": 0,
+                            "microseconds": 0
+                        },
+                        "total": {
+                            "seconds": 0,
+                            "microseconds": 0
+                        },
+                        "user": {
+                            "seconds": 0,
+                            "microseconds": 0
+                        }
+                    },
+                    "exit_code": {
+                        "status": [
+                            "SUCCESS"
+                        ],
+                        "return_code": {
+                            "set": true,
+                            "infinite": false,
+                            "number": 0
+                        },
+                        "signal": {
+                            "id": {
+                                "set": false,
+                                "infinite": false,
+                                "number": 0
+                            },
+                            "name": ""
+                        }
+                    },
+                    "nodes": {
+                        "count": 1,
+                        "range": "localhost",
+                        "list": [
+                            "localhost"
+                        ]
+                    },
+                    "tasks": {
+                        "count": 1
+                    },
+                    "pid": "",
+                    "CPU": {
+                        "requested_frequency": {
+                            "min": {
+                                "set": true,
+                                "infinite": false,
+                                "number": 0
+                            },
+                            "max": {
+                                "set": true,
+                                "infinite": false,
+                                "number": 0
+                            }
+                        },
+                        "governor": "0"
+                    },
+                    "kill_request_user": "",
+                    "state": [
+                        "COMPLETED"
+                    ],
+                    "statistics": {
+                        "CPU": {
+                            "actual_frequency": 0
+                        },
+                        "energy": {
+                            "consumed": {
+                                "set": true,
+                                "infinite": false,
+                                "number": 0
+                            }
+                        }
+                    },
+                    "step": {
+                        "id": "1.batch",
+                        "name": "batch"
+                    },
+                    "task": {
+                        "distribution": "Unknown"
+                    },
+                    "tres": {
+                        "requested": {
+                            "max": [],
+                            "min": [],
+                            "average": [],
+                            "total": []
+                        },
+                        "consumed": {
+                            "max": [],
+                            "min": [],
+                            "average": [],
+                            "total": []
+                        },
+                        "allocated": [
+                            {
+                                "type": "cpu",
+                                "name": "",
+                                "id": 1,
+                                "count": 1
+                            },
+                            {
+                                "type": "mem",
+                                "name": "",
+                                "id": 2,
+                                "count": 1000
+                            },
+                            {
+                                "type": "node",
+                                "name": "",
+                                "id": 4,
+                                "count": 1
+                            }
+                        ]
+                    }
+                }
+            ],
+            "submit_line": "sbatch --export=ALL,F7T_version=v2.0.0 --chdir=/home/fireuser --job-name=SbatchTest --error=/home/fireuser/job.err --output=/home/fireuser/job.out --input=/dev/null",
+            "tres": {
+                "allocated": [
+                    {
+                        "type": "cpu",
+                        "name": "",
+                        "id": 1,
+                        "count": 1
+                    },
+                    {
+                        "type": "mem",
+                        "name": "",
+                        "id": 2,
+                        "count": 1000
+                    },
+                    {
+                        "type": "energy",
+                        "name": "",
+                        "id": 3,
+                        "count": -2
+                    },
+                    {
+                        "type": "node",
+                        "name": "",
+                        "id": 4,
+                        "count": 1
+                    },
+                    {
+                        "type": "billing",
+                        "name": "",
+                        "id": 5,
+                        "count": 1
+                    }
+                ],
+                "requested": [
+                    {
+                        "type": "cpu",
+                        "name": "",
+                        "id": 1,
+                        "count": 1
+                    },
+                    {
+                        "type": "mem",
+                        "name": "",
+                        "id": 2,
+                        "count": 1000
+                    },
+                    {
+                        "type": "node",
+                        "name": "",
+                        "id": 4,
+                        "count": 1
+                    },
+                    {
+                        "type": "billing",
+                        "name": "",
+                        "id": 5,
+                        "count": 1
+                    }
+                ]
+            },
+            "used_gres": "",
+            "user": "fireuser",
+            "wckey": {
+                "wckey": "",
+                "flags": []
+            },
+            "working_directory": "/home/fireuser"
+        },
+        {
+            "account": "staff",
+            "comment": {
+                "administrator": "",
+                "job": "",
+                "system": ""
+            },
+            "allocation_nodes": 1,
+            "array": {
+                "job_id": 0,
+                "limits": {
+                    "max": {
+                        "running": {
+                            "tasks": 0
+                        }
+                    }
+                },
+                "task_id": {
+                    "set": false,
+                    "infinite": false,
+                    "number": 0
+                },
+                "task": ""
+            },
+            "association": {
+                "account": "staff",
+                "cluster": "cluster",
+                "partition": "",
+                "user": "firesrv",
+                "id": 8
+            },
+            "block": "",
+            "cluster": "cluster",
+            "constraints": "",
+            "container": "",
+            "derived_exit_code": {
+                "status": [
+                    "SUCCESS"
+                ],
+                "return_code": {
+                    "set": true,
+                    "infinite": false,
+                    "number": 0
+                },
+                "signal": {
+                    "id": {
+                        "set": false,
+                        "infinite": false,
+                        "number": 0
+                    },
+                    "name": ""
+                }
+            },
+            "time": {
+                "elapsed": 101,
+                "eligible": 1748943386,
+                "end": 1748943649,
+                "planned": {
+                    "set": true,
+                    "infinite": false,
+                    "number": 162
+                },
+                "start": 1748943548,
+                "submission": 1748943386,
+                "suspended": 0,
+                "system": {
+                    "seconds": 0,
+                    "microseconds": 0
+                },
+                "limit": {
+                    "set": true,
+                    "infinite": false,
+                    "number": 7200
+                },
+                "total": {
+                    "seconds": 0,
+                    "microseconds": 0
+                },
+                "user": {
+                    "seconds": 0,
+                    "microseconds": 0
+                }
+            },
+            "exit_code": {
+                "status": [
+                    "SUCCESS"
+                ],
+                "return_code": {
+                    "set": true,
+                    "infinite": false,
+                    "number": 0
+                },
+                "signal": {
+                    "id": {
+                        "set": false,
+                        "infinite": false,
+                        "number": 0
+                    },
+                    "name": ""
+                }
+            },
+            "extra": "",
+            "failed_node": "",
+            "flags": [
+                "STARTED_ON_BACKFILL",
+                "START_RECEIVED"
+            ],
+            "group": "service-accounts",
+            "het": {
+                "job_id": 0,
+                "job_offset": {
+                    "set": false,
+                    "infinite": false,
+                    "number": 0
+                }
+            },
+            "job_id": 4,
+            "name": "sbatch.sh",
+            "licenses": "",
+            "mcs": {
+                "label": ""
+            },
+            "nodes": "localhost",
+            "partition": "part01",
+            "hold": false,
+            "priority": {
+                "set": true,
+                "infinite": false,
+                "number": 1
+            },
+            "qos": "normal",
+            "qosreq": "",
+            "required": {
+                "CPUs": 1,
+                "memory_per_cpu": {
+                    "set": false,
+                    "infinite": false,
+                    "number": 0
+                },
+                "memory_per_node": {
+                    "set": true,
+                    "infinite": false,
+                    "number": 0
+                }
+            },
+            "kill_request_user": "",
+            "restart_cnt": 0,
+            "reservation": {
+                "id": 0,
+                "name": ""
+            },
+            "script": "",
+            "stdin_expanded": "/dev/null",
+            "stdout_expanded": "/home/firesrv/slurm-4.out",
+            "stderr_expanded": "",
+            "stdout": "/home/firesrv/slurm-%j.out",
+            "stderr": "",
+            "stdin": "/dev/null",
+            "state": {
+                "current": [
+                    "COMPLETED"
+                ],
+                "reason": "None"
+            },
+            "steps": [
+                {
+                    "time": {
+                        "elapsed": 101,
+                        "end": {
+                            "set": true,
+                            "infinite": false,
+                            "number": 1748943649
+                        },
+                        "start": {
+                            "set": true,
+                            "infinite": false,
+                            "number": 1748943548
+                        },
+                        "suspended": 0,
+                        "system": {
+                            "seconds": 0,
+                            "microseconds": 0
+                        },
+                        "total": {
+                            "seconds": 0,
+                            "microseconds": 0
+                        },
+                        "user": {
+                            "seconds": 0,
+                            "microseconds": 0
+                        }
+                    },
+                    "exit_code": {
+                        "status": [
+                            "SUCCESS"
+                        ],
+                        "return_code": {
+                            "set": true,
+                            "infinite": false,
+                            "number": 0
+                        },
+                        "signal": {
+                            "id": {
+                                "set": false,
+                                "infinite": false,
+                                "number": 0
+                            },
+                            "name": ""
+                        }
+                    },
+                    "nodes": {
+                        "count": 1,
+                        "range": "localhost",
+                        "list": [
+                            "localhost"
+                        ]
+                    },
+                    "tasks": {
+                        "count": 1
+                    },
+                    "pid": "",
+                    "CPU": {
+                        "requested_frequency": {
+                            "min": {
+                                "set": true,
+                                "infinite": false,
+                                "number": 0
+                            },
+                            "max": {
+                                "set": true,
+                                "infinite": false,
+                                "number": 0
+                            }
+                        },
+                        "governor": "0"
+                    },
+                    "kill_request_user": "",
+                    "state": [
+                        "COMPLETED"
+                    ],
+                    "statistics": {
+                        "CPU": {
+                            "actual_frequency": 0
+                        },
+                        "energy": {
+                            "consumed": {
+                                "set": true,
+                                "infinite": false,
+                                "number": 0
+                            }
+                        }
+                    },
+                    "step": {
+                        "id": "4.batch",
+                        "name": "batch"
+                    },
+                    "task": {
+                        "distribution": "Unknown"
+                    },
+                    "tres": {
+                        "requested": {
+                            "max": [],
+                            "min": [],
+                            "average": [],
+                            "total": []
+                        },
+                        "consumed": {
+                            "max": [],
+                            "min": [],
+                            "average": [],
+                            "total": []
+                        },
+                        "allocated": [
+                            {
+                                "type": "cpu",
+                                "name": "",
+                                "id": 1,
+                                "count": 1
+                            },
+                            {
+                                "type": "mem",
+                                "name": "",
+                                "id": 2,
+                                "count": 1000
+                            },
+                            {
+                                "type": "node",
+                                "name": "",
+                                "id": 4,
+                                "count": 1
+                            }
+                        ]
+                    }
+                }
+            ],
+            "submit_line": "sbatch sbatch.sh",
+            "tres": {
+                "allocated": [
+                    {
+                        "type": "cpu",
+                        "name": "",
+                        "id": 1,
+                        "count": 1
+                    },
+                    {
+                        "type": "mem",
+                        "name": "",
+                        "id": 2,
+                        "count": 1000
+                    },
+                    {
+                        "type": "energy",
+                        "name": "",
+                        "id": 3,
+                        "count": -2
+                    },
+                    {
+                        "type": "node",
+                        "name": "",
+                        "id": 4,
+                        "count": 1
+                    },
+                    {
+                        "type": "billing",
+                        "name": "",
+                        "id": 5,
+                        "count": 1
+                    }
+                ],
+                "requested": [
+                    {
+                        "type": "cpu",
+                        "name": "",
+                        "id": 1,
+                        "count": 1
+                    },
+                    {
+                        "type": "mem",
+                        "name": "",
+                        "id": 2,
+                        "count": 1000
+                    },
+                    {
+                        "type": "node",
+                        "name": "",
+                        "id": 4,
+                        "count": 1
+                    },
+                    {
+                        "type": "billing",
+                        "name": "",
+                        "id": 5,
+                        "count": 1
+                    }
+                ]
+            },
+            "used_gres": "",
+            "user": "firesrv",
+            "wckey": {
+                "wckey": "",
+                "flags": []
+            },
+            "working_directory": "/home/firesrv"
+        }
+    ]
+}

--- a/tests/mocked_ssh_outputs/ssh_sacct_allusers_command.json
+++ b/tests/mocked_ssh_outputs/ssh_sacct_allusers_command.json
@@ -1,0 +1,6 @@
+{
+    "stdout": "3|1|cluster|0:0|users|staff|SbatchTest|localhost|part01|1|COMPLETED|None|100|2025-06-03T09:34:07|2025-06-03T09:37:28|2025-06-03T09:39:08|00:00:00|7200|fireuser|/home/fireuser\n4|1|cluster|0:0|service-accounts|staff|sbatch.sh|localhost|part01|1|COMPLETED|None|101|2025-06-03T09:36:26|2025-06-03T09:39:08|2025-06-03T09:40:49|00:00:00|7200|firesrv|/home/firesrv",
+    "stderr": "",
+    "exit_code": 0,
+    "command": "sacct --allusers --noheader --parsable2 --format='JobID,AllocNodes,Cluster,ExitCode,Group,Account,JobName,NodeList,Partition,Priority,State,Reason,ElapsedRaw,Submit,Start,End,Suspended,TimelimitRaw,User,WorkDir'"
+}

--- a/tests/mocked_ssh_outputs/ssh_sacct_command.json
+++ b/tests/mocked_ssh_outputs/ssh_sacct_command.json
@@ -1,6 +1,6 @@
 {
-    "stdout": "2|1|cluster|0:0|test1|test|sbatch|localhost|part01|4294901758|COMPLETED|None|18|2024-05-06T08:36:56|2024-05-06T08:36:56|2024-05-06T08:37:14|00:00:00|7200|test1|/home/test1\n13|1|cluster||test1|test|sbatch|localhost|part01|4294901758|COMPLETED|None|18|2024-05-06T08:36:56|2024-05-06T08:36:56|2024-05-06T08:37:14|00:00:00|7200|test1|/home/test1",
+    "stdout": "1|1|cluster|0:0|users|staff|SbatchTest|localhost|part01|1|COMPLETED|None|100|2025-06-03T09:34:05|2025-06-03T09:34:06|2025-06-03T09:35:46|00:00:00|7200|fireuser|/home/fireuser",
     "stderr": "",
     "exit_code": 0,
-    "command":"sacct --jobs='1' --noheader --parsable2 --format='JobID,AllocNodes,Cluster,ExitCode,Group,Account,JobName,NodeList,Partition,Priority,State,Reason,ElapsedRaw,Submit,Start,End,Suspended,TimelimitRaw,User,WorkDir'"
+    "command":"sacct --allusers --jobs='1' --noheader --parsable2 --format='JobID,AllocNodes,Cluster,ExitCode,Group,Account,JobName,NodeList,Partition,Priority,State,Reason,ElapsedRaw,Submit,Start,End,Suspended,TimelimitRaw,User,WorkDir'"
 }

--- a/tests/mocked_ssh_outputs/ssh_sacct_command.json
+++ b/tests/mocked_ssh_outputs/ssh_sacct_command.json
@@ -2,5 +2,5 @@
     "stdout": "2|1|cluster|0:0|test1|test|sbatch|localhost|part01|4294901758|COMPLETED|None|18|2024-05-06T08:36:56|2024-05-06T08:36:56|2024-05-06T08:37:14|00:00:00|7200|test1|/home/test1\n13|1|cluster||test1|test|sbatch|localhost|part01|4294901758|COMPLETED|None|18|2024-05-06T08:36:56|2024-05-06T08:36:56|2024-05-06T08:37:14|00:00:00|7200|test1|/home/test1",
     "stderr": "",
     "exit_code": 0,
-    "command":"sacct --user=test-user --jobs='1' --noheader --parsable2 --format='JobID,AllocNodes,Cluster,ExitCode,Group,Account,JobName,NodeList,Partition,Priority,State,Reason,ElapsedRaw,Submit,Start,End,Suspended,TimelimitRaw,User,WorkDir'"
+    "command":"sacct --jobs='1' --noheader --parsable2 --format='JobID,AllocNodes,Cluster,ExitCode,Group,Account,JobName,NodeList,Partition,Priority,State,Reason,ElapsedRaw,Submit,Start,End,Suspended,TimelimitRaw,User,WorkDir'"
 }


### PR DESCRIPTION
The `allusers` query parameter is used to show all users' jobs when querying for jobs. By default, it's set to `False`.

Additionally, added unit tests.
