### PR TITLE
Fix for Slurm timestamp parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed Slurm timestamps parsing issues, timezone was not properly handled.
+
 ## [2.2.7]
 
 ### Added

--- a/src/lib/scheduler_clients/slurm/cli_commands/sacct_base.py
+++ b/src/lib/scheduler_clients/slurm/cli_commands/sacct_base.py
@@ -12,17 +12,15 @@ from lib.ssh_clients.ssh_client import BaseCommand
 class SacctCommandBase(BaseCommand):
 
     def __init__(
-            self,
-            username: str = None,
-            job_ids: List[str] = None,
-            allusers: bool = False) -> None:
+        self, username: str = None, job_ids: List[str] = None, allusers: bool = False
+    ) -> None:
         super().__init__()
         self.username = username
         self.allusers = allusers
         self.job_ids = job_ids
 
     def get_command(self) -> str:
-        cmd = ["sacct"]
+        cmd = ["SLURM_TIME_FORMAT='%s' sacct"]
         if self.allusers:
             cmd += ["--allusers"]
         if self.job_ids:

--- a/src/lib/scheduler_clients/slurm/cli_commands/sacct_job_info_command.py
+++ b/src/lib/scheduler_clients/slurm/cli_commands/sacct_job_info_command.py
@@ -5,16 +5,8 @@
 
 # commands
 from datetime import datetime
-import time
 from lib.exceptions import SlurmError
 from lib.scheduler_clients.slurm.cli_commands.sacct_base import SacctCommandBase
-
-
-def _datestr_to_epoc(datestr: str):
-    try:
-        return time.mktime(time.strptime(datestr, "%Y-%m-%dT%H:%M:%S"))
-    except ValueError:
-        return None
 
 
 def _timestr_to_seconds(timestr: str):
@@ -81,9 +73,9 @@ class SacctCommand(SacctCommandBase):
             "state": {"current": job_info[10], "reason": job_info[11]},
             "time": {
                 "elapsed": job_info[12],
-                "submission": _datestr_to_epoc(job_info[13]),
-                "start": _datestr_to_epoc(job_info[14]),
-                "end": _datestr_to_epoc(job_info[15]),
+                "submission": job_info[13],
+                "start": job_info[14],
+                "end": job_info[15],
                 "suspended": _timestr_to_seconds(job_info[16]),
                 "limit": int(job_info[17]) if job_info[17] else None,
             },
@@ -106,9 +98,9 @@ class SacctCommand(SacctCommandBase):
             ),
             "time": {
                 "elapsed": job_info[12],
-                "submission": _datestr_to_epoc(job_info[13]),
-                "start": _datestr_to_epoc(job_info[14]),
-                "end": _datestr_to_epoc(job_info[15]),
+                "submission": job_info[13],
+                "start": job_info[14],
+                "end": job_info[15],
                 "suspended": _timestr_to_seconds(job_info[16]),
                 "limit": int(job_info[17]) if job_info[17] else None,
             },

--- a/tests/mocked_ssh_outputs/ssh_sacct_allusers_command.json
+++ b/tests/mocked_ssh_outputs/ssh_sacct_allusers_command.json
@@ -1,5 +1,5 @@
 {
-    "stdout": "3|1|cluster|0:0|users|staff|SbatchTest|localhost|part01|1|COMPLETED|None|100|2025-06-03T09:34:07|2025-06-03T09:37:28|2025-06-03T09:39:08|00:00:00|7200|fireuser|/home/fireuser\n4|1|cluster|0:0|service-accounts|staff|sbatch.sh|localhost|part01|1|COMPLETED|None|101|2025-06-03T09:36:26|2025-06-03T09:39:08|2025-06-03T09:40:49|00:00:00|7200|firesrv|/home/firesrv",
+    "stdout": "3|1|cluster|0:0|users|staff|SbatchTest|localhost|part01|1|COMPLETED|None|100|1750232859|1750232859|1750232859|00:00:00|7200|fireuser|/home/fireuser\n4|1|cluster|0:0|service-accounts|staff|sbatch.sh|localhost|part01|1|COMPLETED|None|101|1750232859|1750232859|1750232859|00:00:00|7200|firesrv|/home/firesrv",
     "stderr": "",
     "exit_code": 0,
     "command": "sacct --allusers --noheader --parsable2 --format='JobID,AllocNodes,Cluster,ExitCode,Group,Account,JobName,NodeList,Partition,Priority,State,Reason,ElapsedRaw,Submit,Start,End,Suspended,TimelimitRaw,User,WorkDir'"

--- a/tests/mocked_ssh_outputs/ssh_sacct_command.json
+++ b/tests/mocked_ssh_outputs/ssh_sacct_command.json
@@ -1,5 +1,5 @@
 {
-    "stdout": "1|1|cluster|0:0|users|staff|SbatchTest|localhost|part01|1|COMPLETED|None|100|2025-06-03T09:34:05|2025-06-03T09:34:06|2025-06-03T09:35:46|00:00:00|7200|fireuser|/home/fireuser",
+    "stdout": "1|1|cluster|0:0|users|staff|SbatchTest|localhost|part01|1|COMPLETED|None|100|1750232859|1750232859|1750232859|00:00:00|7200|fireuser|/home/fireuser",
     "stderr": "",
     "exit_code": 0,
     "command":"sacct --allusers --jobs='1' --noheader --parsable2 --format='JobID,AllocNodes,Cluster,ExitCode,Group,Account,JobName,NodeList,Partition,Priority,State,Reason,ElapsedRaw,Submit,Start,End,Suspended,TimelimitRaw,User,WorkDir'"


### PR DESCRIPTION
This fix resolves issue #92 
Adds a Slurm env variable to output timestamps in epoch format avoiding the need to account for timezones.