### PR TITLE
Change MaxBuckets to paginator in health check for GCP compatibility

### DIFF
--- a/src/firecrest/status/health_check/checks/health_check_s3.py
+++ b/src/firecrest/status/health_check/checks/health_check_s3.py
@@ -27,8 +27,10 @@ class S3HealthCheck(HealthCheckBase):
         async with await S3ClientDependency(
             connection=S3ClientConnectionType.private
         )() as s3_client:
-
-            await s3_client.list_buckets(MaxBuckets=1)
+            paginator = s3_client.get_paginator("list_buckets")
+            iterator = paginator.paginate(PaginationConfig={"MaxItems": 1})
+            async for _page in iterator:
+                pass
 
         return health
 


### PR DESCRIPTION
Fix #99

Uses [paginator](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/paginators.html) to limit payload from S3 API instead of the `MaxBuckets` argument.

This makes `health_check_s3.py` compatible with GCP's Cloud Storage buckets.