### PR TITLE
Iram 370 mount clusters config files

### DIFF
--- a/build/helm/firecrest-api/templates/firecrest-api-depl.yaml
+++ b/build/helm/firecrest-api/templates/firecrest-api-depl.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
   {{- range $key, $value := .Values.metadata.annotations }}
     {{ $key }}: {{ $value | quote }}
+  {{- end }}
 
 spec:
   replicas: {{ .Values.replicas }}

--- a/build/helm/firecrest-api/templates/firecrest-api-depl.yaml
+++ b/build/helm/firecrest-api/templates/firecrest-api-depl.yaml
@@ -2,9 +2,13 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: firecrest-api-depl
+  {{- with .Values.metadata }}
+  {{- with .annotations }}
   annotations:
   {{- range $key, $value := .Values.metadata.annotations }}
     {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
   {{- end }}
 
 spec:
@@ -16,35 +20,47 @@ spec:
     metadata:
       labels:
         app: firecrest-api
+      {{- with .Values.template }}
+      {{- with .annotations }}
       annotations:
       {{- range $key, $value := .Values.template.annotations }}
         {{ $key }}: {{ $value | quote}}
+        {{- end }}
+      {{- end }}
       {{- end }}
     spec:
       containers:
         - name: firecrest-api
           image: "{{ .Values.image }}:{{ .Chart.AppVersion }}"
           env:
+            {{- if .Values.global }}
             - name: ENVIRONMENT
               value: {{ .Values.global.environment }}
+            {{- end }}
             - name: YAML_CONFIG_FILE
               value: "/app/configs/firecrest-config.yaml"
+            {{- if .Values.loggingLevel }}
             - name: LOGGING_LEVEL
               value: {{ .Values.loggingLevel }}
+            {{- end }}
             {{- if .Values.logConfig }}
             - name: UVICORN_LOG_CONFIG
               value: {{ .Values.logConfig }}
             {{- end }}
           volumeMounts:
-          - name: firecrest-configs-volume
+          {{- range .Values.volumes }}
+          - name: {{ .name }}
+            {{- if eq .name "firecrest-configs-volume" -}}
             mountPath: /app/configs/
-            readOnly: true
-          - name: firecrest-secrets-volume
+            {{- else if eq .name "firecrest-secrets-volume" -}}
             mountPath: /app/secrets/
-            readOnly: true
-          - name: firecrest-clusters-configs-volume
+            {{- else if eq .name "firecrest-clusters-configs-volume" -}}
             mountPath: /app/clusters/
-            readOnly: true
+            {{- else -}}
+            mountPath: /app/{{ .name }}/            
+            {{- end -}}
+            readOnly : true
+          {{- end -}}
           livenessProbe:
             exec:
               command:
@@ -75,7 +91,6 @@ spec:
             {{- end }}
           {{- end }}
         {{- end }}
-
             
 ---
 apiVersion: v1
@@ -88,5 +103,9 @@ spec:
   ports:
     - name: firecrest-api
       protocol: TCP
+      {{- if and .Values.service .Values.service.port -}}
       port: {{ .Values.service.port }}
+      {{- else }}
+      port: 5001
+      {{- end }}
       targetPort: 5000

--- a/build/helm/firecrest-api/templates/firecrest-api-depl.yaml
+++ b/build/helm/firecrest-api/templates/firecrest-api-depl.yaml
@@ -2,9 +2,11 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: firecrest-api-depl
+  {{- if .Values.metadata }}
   annotations:
   {{- range $key, $value := .Values.metadata.annotations }}
     {{ $key }}: {{ $value | quote }}
+  {{- end }}
   {{- end }}
 
 spec:
@@ -16,9 +18,11 @@ spec:
     metadata:
       labels:
         app: firecrest-api
+      {{- if .Values.template }}
       annotations:
       {{- range $key, $value := .Values.template.annotations }}
         {{ $key }}: {{ $value | quote}}
+      {{- end }}
       {{- end }}
     spec:
       containers:
@@ -42,17 +46,17 @@ spec:
           volumeMounts:
           {{- range .Values.volumes }}
           - name: {{ .name }}
-            {{- if eq .name "firecrest-configs-volume" -}}
+            {{- if eq .name "firecrest-configs-volume" }}
             mountPath: /app/configs/
-            {{- else if eq .name "firecrest-secrets-volume" -}}
+            {{- else if eq .name "firecrest-secrets-volume" }}
             mountPath: /app/secrets/
-            {{- else if eq .name "firecrest-clusters-configs-volume" -}}
+            {{- else if eq .name "firecrest-clusters-configs-volume" }}
             mountPath: /app/clusters/
-            {{- else -}}
+            {{- else }}
             mountPath: /app/{{ .name }}/            
-            {{- end -}}
+            {{- end }}
             readOnly : true
-          {{- end -}}
+          {{- end }}
           livenessProbe:
             exec:
               command:

--- a/build/helm/firecrest-api/templates/firecrest-api-depl.yaml
+++ b/build/helm/firecrest-api/templates/firecrest-api-depl.yaml
@@ -42,6 +42,11 @@ spec:
           - name: firecrest-secrets-volume
             mountPath: /app/secrets/
             readOnly: true
+          {{- if has "firecrest-clusters-configs-volume" .Values.volumes }}
+          - name: firecrest-clusters-configs-volume
+            mountPath: /app/clusters/
+            readOnly: true
+          {{- end}}
           livenessProbe:
             exec:
               command:

--- a/build/helm/firecrest-api/templates/firecrest-api-depl.yaml
+++ b/build/helm/firecrest-api/templates/firecrest-api-depl.yaml
@@ -2,14 +2,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: firecrest-api-depl
-  {{- with .Values.metadata }}
-  {{- with .annotations }}
   annotations:
   {{- range $key, $value := .Values.metadata.annotations }}
     {{ $key }}: {{ $value | quote }}
-    {{- end }}
-  {{- end }}
-  {{- end }}
 
 spec:
   replicas: {{ .Values.replicas }}
@@ -20,13 +15,9 @@ spec:
     metadata:
       labels:
         app: firecrest-api
-      {{- with .Values.template }}
-      {{- with .annotations }}
       annotations:
       {{- range $key, $value := .Values.template.annotations }}
         {{ $key }}: {{ $value | quote}}
-        {{- end }}
-      {{- end }}
       {{- end }}
     spec:
       containers:
@@ -103,9 +94,5 @@ spec:
   ports:
     - name: firecrest-api
       protocol: TCP
-      {{- if and .Values.service .Values.service.port -}}
       port: {{ .Values.service.port }}
-      {{- else }}
-      port: 5001
-      {{- end }}
       targetPort: 5000

--- a/build/helm/firecrest-api/templates/firecrest-api-depl.yaml
+++ b/build/helm/firecrest-api/templates/firecrest-api-depl.yaml
@@ -42,11 +42,11 @@ spec:
           - name: firecrest-secrets-volume
             mountPath: /app/secrets/
             readOnly: true
-          {{- if has "firecrest-clusters-configs-volume" .Values.volumes }}
+          # {{- if has "firecrest-clusters-configs-volume" .Values.volumes }}
           - name: firecrest-clusters-configs-volume
             mountPath: /app/clusters/
             readOnly: true
-          {{- end}}
+          # {{- end}}
           livenessProbe:
             exec:
               command:

--- a/build/helm/firecrest-api/templates/firecrest-api-depl.yaml
+++ b/build/helm/firecrest-api/templates/firecrest-api-depl.yaml
@@ -42,11 +42,9 @@ spec:
           - name: firecrest-secrets-volume
             mountPath: /app/secrets/
             readOnly: true
-          # {{- if has "firecrest-clusters-configs-volume" .Values.volumes }}
           - name: firecrest-clusters-configs-volume
             mountPath: /app/clusters/
             readOnly: true
-          # {{- end}}
           livenessProbe:
             exec:
               command:

--- a/src/firecrest/config.py
+++ b/src/firecrest/config.py
@@ -435,7 +435,7 @@ class Settings(BaseSettings):
                     f"Clusters config path: {path} is not a folder!"
                 )
             clusters = []
-            for file in Path(path).rglob("*.yaml"):
+            for file in Path(path).glob("*.yaml"):
                 with open(file) as stream:
                     clusters.append(
                         HPCCluster.model_validate(yaml.safe_load(stream))

--- a/src/firecrest/config.py
+++ b/src/firecrest/config.py
@@ -435,13 +435,11 @@ class Settings(BaseSettings):
                     f"Clusters config path: {path} is not a folder!"
                 )
             clusters = []
-            for dirpath, _dirs, files in os.walk(path):
-                for file in files:
-                    if file.endswith(".yaml"):
-                        with open(os.path.join(dirpath, file)) as stream:
-                            clusters.append(
-                                HPCCluster.model_validate(yaml.safe_load(stream))
-                            )
+            for file in Path(path).rglob("*.yaml"):
+                with open(file) as stream:
+                    clusters.append(
+                        HPCCluster.model_validate(yaml.safe_load(stream))
+                )
             return clusters
         else:
             return value


### PR DESCRIPTION
Updated Helm chart:
- mount points enabled automatically if related configMap/secret is declared in values.yaml
- added optional mount point for /app/clusters configuration files directory
- environment variables are "guarded" to be disabled if not declared in values.yaml
-  some nil fix managing empty annotations

Clusters configuration yaml files were loaded from a directory recursively including hidden files and directories. That was problematic with K8s mounts. As a proposal I simplified the process skipping hidden files and folders and avoiding recursion.
