### PR TITLE
Add ssl context for host verification in httpx client

### DIFF
--- a/src/firecrest/status/health_check/health_checker_cluster.py
+++ b/src/firecrest/status/health_check/health_checker_cluster.py
@@ -22,6 +22,9 @@ from lib.auth.authN.OIDC_token_auth import OIDCTokenAuth
 from lib.scheduler_clients.scheduler_base_client import SchedulerBaseClient
 from authlib.integrations.httpx_client import AsyncOAuth2Client
 from firecrest.plugins import settings
+import ssl
+import certifi
+import os
 
 
 class ClusterHealthChecker:
@@ -41,9 +44,13 @@ class ClusterHealthChecker:
 
     async def check(self) -> None:
         try:
+            ctx = ssl.create_default_context(
+                cafile=os.environ.get("REQUESTS_CA_BUNDLE", certifi.where()),
+            )
             client = AsyncOAuth2Client(
                 self.cluster.service_account.client_id,
                 self.cluster.service_account.secret.get_secret_value(),
+                verify=ctx,
             )
 
             token = await client.fetch_token(


### PR DESCRIPTION
Fix #95 

Creates an SSL context using the CA certificate bundle specified in `REQUESTS_CA_BUNDLE` or the one provided `certifi` package. Then use this context for SSL verification in the `httpx` client used during cluster health checks.

The purpose of this is for the `httpx` client to mimic the configuration of the `requests` client.