### PR TITLE
[Experimental] Interactive Attach end-point

### DIFF
--- a/src/firecrest/main.py
+++ b/src/firecrest/main.py
@@ -44,6 +44,7 @@ from firecrest.status.router import (
     router_liveness as status_liveness_router,
 )
 from firecrest.compute.router import router as compute_router
+from firecrest.compute.router import router_ws as compute_router_ws
 from firecrest.filesystem.router import router as filesystem_router
 from lib.scheduler_clients import SlurmRestClient
 
@@ -173,6 +174,7 @@ def register_routes(app: FastAPI, settings: config.Settings):
     app.include_router(status_system_router)
     app.include_router(status_liveness_router)
     app.include_router(compute_router)
+    app.include_router(compute_router_ws)
     app.include_router(filesystem_router)
 
 

--- a/src/lib/scheduler_clients/pbs/pbs_client.py
+++ b/src/lib/scheduler_clients/pbs/pbs_client.py
@@ -83,6 +83,15 @@ class PbsClient(SchedulerBaseClient):
             "Interactive attach is not supported in PBS CLI client"
         )
 
+    async def attach_command_proccess(
+        self,
+        command: str,
+        job_id: str,
+        username: str,
+        jwt_token: str,
+    ) -> int | None:
+        pass
+
     async def get_job(
         self, job_id: str | None, username: str, jwt_token: str, allusers: bool = True
     ) -> List[PbsJob] | None:

--- a/src/lib/scheduler_clients/scheduler_base_client.py
+++ b/src/lib/scheduler_clients/scheduler_base_client.py
@@ -39,13 +39,19 @@ class SchedulerBaseClient(ABC):
         pass
 
     @abstractmethod
-    # Note: returns multiple jobs to deal with job_id duplicates (see Slurm doc)
-    async def get_job(
+    async def attach_command_proccess(
         self,
+        command: str,
         job_id: str,
         username: str,
         jwt_token: str,
-        allusers: bool = True
+    ) -> int | None:
+        pass
+
+    @abstractmethod
+    # Note: returns multiple jobs to deal with job_id duplicates (see Slurm doc)
+    async def get_job(
+        self, job_id: str, username: str, jwt_token: str, allusers: bool = True
     ) -> List[JobModel]:
         pass
 
@@ -58,10 +64,7 @@ class SchedulerBaseClient(ABC):
 
     @abstractmethod
     async def get_jobs(
-        self,
-        username: str,
-        jwt_token: str,
-        allusers: bool = False
+        self, username: str, jwt_token: str, allusers: bool = False
     ) -> List[JobModel] | None:
         pass
 

--- a/src/lib/scheduler_clients/slurm/slurm_base_client.py
+++ b/src/lib/scheduler_clients/slurm/slurm_base_client.py
@@ -39,6 +39,16 @@ class SlurmBaseClient(SchedulerBaseClient):
         pass
 
     @abstractmethod
+    async def attach_command_proccess(
+        self,
+        command: str,
+        job_id: str,
+        username: str,
+        jwt_token: str,
+    ) -> None:
+        pass
+
+    @abstractmethod
     # Note: returns multiple jobs to deal with job_id duplicates (see Slurm doc)
     async def get_job(
         self, job_id: str, username: str, jwt_token: str, allusers: bool = True

--- a/src/lib/scheduler_clients/slurm/slurm_client.py
+++ b/src/lib/scheduler_clients/slurm/slurm_client.py
@@ -1,3 +1,4 @@
+from contextlib import asynccontextmanager
 from typing import List
 
 from lib.scheduler_clients.slurm.models import (
@@ -64,6 +65,19 @@ class SlurmClient(SlurmBaseClient):
         return await self.slurm_default_client.attach_command(
             command, job_id, username, jwt_token
         )
+
+    @asynccontextmanager
+    async def attach_command_proccess(
+        self,
+        command: str,
+        job_id: str,
+        username: str,
+        jwt_token: str,
+    ):
+        async with self.slurm_default_client.attach_command_proccess(
+            command, job_id, username, jwt_token
+        ) as process:
+            yield process
 
     async def get_job(
         self, job_id: str | None, username: str, jwt_token: str, allusers: bool = True

--- a/src/lib/scheduler_clients/slurm/slurm_rest_client.py
+++ b/src/lib/scheduler_clients/slurm/slurm_rest_client.py
@@ -139,6 +139,15 @@ class SlurmRestClient(SlurmBaseClient):
     ) -> int | None:
         pass
 
+    async def attach_command_proccess(
+        self,
+        command: str,
+        job_id: str,
+        username: str,
+        jwt_token: str,
+    ) -> int | None:
+        pass
+
     async def get_job(
         self, job_id: str, username: str, jwt_token: str, allusers: bool = True
     ) -> List[SlurmJob] | None:


### PR DESCRIPTION
A new experimental feature to provide a streaming endpoint (web socket) to enable interactive use cases.

The /compute/job/{job_id}/attach  end-point has been refactored as a web socket.

### How it works

The attach end-point will execute the provided **cmd** (e.g. /bin/bash) using `srun` and pipe the stdin, stdout, and stderr to the web socket. If the provided job_id is 0 srun will spawn a new job; otherwise the **cmd** will be executed as a step of the provided job_iod.

### Testing the feature

1) Install a web socket client (e.g. [Simple web socket extension](https://chromewebstore.google.com/detail/simple-websocket-client/gobngblklhkgmjhbpbdlkglbhhlafjnh?hl=en))
2) open the socket `ws://localhost:8000/compute/cluster-slurm-ssh/jobs/0/attach?cmd=/bin/bash&token={token}`
3) send commands `ls /etc/slurm/' **important:** add carriage return at the end of the command to execute.

### TODOs and criticalities:

1. Refactor the auth dependency to work with JWT provided as query param
2. Mitigate the risk of exhausting the SSH connection pool