### PR TITLE
Added debug info on certificates on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.3.0] - OPEN
+## [2.3.1] - OPEN
+
+### Added
+
+- Certificates debug information when SSH connection fails
+
+### Changed
+
+### Fixed
+
+## [2.3.0]
 
 ### Added
 


### PR DESCRIPTION
Opening the discussion here:

- Debug data of the certificate used by the user will be logged when the exception raised is [PermissionDenied](https://asyncssh.readthedocs.io/en/latest/api.html#asyncssh.PermissionDenied), which could be related to credentials, and [ProtocolError](https://asyncssh.readthedocs.io/en/latest/api.html#asyncssh.ProtocolError), because it was identified in our logs with `Too many authentication failures` error.

- To log, we use the `error` mode of `uvicorn` logger (instead of just a `print()`)

- The idea is to start logging only the username (principal), algorithm, valid dates of the certificates, serial numbers, and the public key