### PR TITLE
Case insensitive system name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The System Name path parameter and the corresponding Cluster name configuration are case insensitive.
+
 ## [2.3.1]
 
 ### Added

--- a/f7t-api-config.local-env-tests.yaml
+++ b/f7t-api-config.local-env-tests.yaml
@@ -8,7 +8,7 @@ ssh_credentials:
   url: "http://192.168.240.20:5000"
   max_connections: 500
 clusters:
-- name: "cluster-slurm-api"
+- name: "cluster-SLURM-api"
   ssh:
     host: "192.168.240.2"
     port: 22
@@ -33,7 +33,7 @@ clusters:
     - path: '/home'
       data_type: 'users'
       default_work_dir: true
-- name: "cluster-slurm-ssh"
+- name: "cluster-SLURM-ssh"
   ssh:
     host: "192.168.240.2"
     port: 22

--- a/src/firecrest/config.py
+++ b/src/firecrest/config.py
@@ -5,6 +5,7 @@
 
 from enum import Enum
 import os
+import pydantic
 import yaml
 from pathlib import Path
 from typing import Any, Dict, Literal, Tuple, Type, Union
@@ -314,7 +315,9 @@ class HPCCluster(CamelModel):
     [the systems' section](../arch/systems//README.md).
     """
 
-    name: str = Field(..., description="Unique name for the cluster.")
+    name: str = Field(
+        ..., description="Unique name for the cluster. This field is case insensitive."
+    )
     ssh: SSHClientPool = Field(
         ..., description="SSH configuration for accessing the cluster nodes."
     )
@@ -344,6 +347,12 @@ class HPCCluster(CamelModel):
         default_factory=list,
         description="Custom scheduler flags passed to data transfer jobs (e.g. `-pxfer` for a dedicated partition).",
     )
+
+    @pydantic.field_validator("name", mode="before")
+    def to_lowercase(cls, value):
+        if isinstance(value, str):
+            return value.lower()
+        return value
 
 
 class OpenFGA(CamelModel):

--- a/src/firecrest/main.py
+++ b/src/firecrest/main.py
@@ -174,6 +174,15 @@ def register_middlewares(app: FastAPI):
             )
             raise e
 
+    @app.middleware("http")
+    async def lower_case_path(request: Request, call_next):
+
+        path = request.scope["path"].lower()
+        request.scope["path"] = path
+
+        response = await call_next(request)
+        return response
+
 
 def register_routes(app: FastAPI, settings: config.Settings):
     app.include_router(status_router)

--- a/tests/clusters_config_test.py
+++ b/tests/clusters_config_test.py
@@ -23,7 +23,11 @@ async def test_settings(app_settings: Settings):
 
     assert app_settings is not None
     assert len(app_settings.clusters) == 3
-    assert app_settings.clusters[0].name == "cluster-slurm-api"
+    assert (
+        # test case insensitive, name is always lower case
+        app_settings.clusters[0].name
+        == "cluster-slurm-api"
+    )
     assert app_settings.clusters[0].scheduler is not None
     assert app_settings.clusters[0].scheduler.type == SchedulerType.slurm
 


### PR DESCRIPTION
This PR introduces a new FastAPI middleware to make all URL path case insensitive (to lower case) and a pydantic  validator to make the cluster name field case insensitive (to lower case) as well.

This change will make the system name path param case insensitive adding flexibility.