### PR TITLE
Add dependency for Slurm service to wait for Keycloak to be healthy  …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The System Name path parameter and the corresponding Cluster name configuration are case insensitive.
+
+### Fixed
+
+- Docker Compose startup: Added dependency for Slurm to wait for Keycloak health check before starting, preventing JWT certificate download failures.
 - Upload and Download transfer endpoints now require to specify transfer directives
 - Installation docs:
     - Helm charts: FirecREST settings are all included in values.yaml file

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,9 @@ services:
     privileged: true
     environment:
       OIDC_CERT_URLS: '["http://192.168.240.3:8080/auth/realms/kcrealm/protocol/openid-connect/certs"]'
+    depends_on:
+      keycloak:
+        condition: service_healthy
     build:
       platforms:
         - linux/amd64


### PR DESCRIPTION
 before starting. This prevents Slurm from getting stuck waiting for
JWT certificates when Keycloak hasn't started yet. This fixes: if docker compose starts in wrong order it will get stuck in circular dependency loop. 