### PR TITLE
`clusters.probing` is now optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Demo Launcher now is adapted correctly to the `data_operation` setup introduced in `2.4.0`
 - Old link to the installation documentation
+- `probing` configuration is optional now for the `clusters` settings
 
 ## [2.4.0]
 

--- a/f7t-api-config.local-env-tests.yaml
+++ b/f7t-api-config.local-env-tests.yaml
@@ -67,9 +67,9 @@ clusters:
   service_account:
     client_id: "firecrest-api"
     secret: ""
-  probing:
-    interval: 60
-    timeout: 10
+  # probing:
+  #   interval: 60
+  #   timeout: 10
   datatransfer_jobs_directives:
     - "#PBS -l nodes=1:ppn=1"
     - "#PBS -l walltime=00:15:00"

--- a/src/firecrest/config.py
+++ b/src/firecrest/config.py
@@ -371,8 +371,8 @@ class HPCCluster(CamelModel):
         None,
         description="Optional health information for different services in the cluster.",
     )
-    probing: Probing = Field(
-        ..., description="Probing configuration for monitoring the cluster."
+    probing: Optional[Probing] = Field(
+        None, description="Probing configuration for monitoring the cluster."
     )
     file_systems: List[FileSystem] = Field(
         default_factory=list,


### PR DESCRIPTION
Removing `probing` from a system configuration disables health check, now is optional, otherwise, FirecREST wouldn't be able to start