### PR TITLE
Fixed identation issue on filesystems check

### DIFF
--- a/src/firecrest/status/health_check/health_checker_cluster.py
+++ b/src/firecrest/status/health_check/health_checker_cluster.py
@@ -84,7 +84,7 @@ class ClusterHealthChecker:
                             path=filesystem.path,
                             timeout=services["filesystems"].timeout,
                         )
-                    checks += [filesystemCheck.check()]
+                        checks += [filesystemCheck.check()]
 
             results = await asyncio.gather(*checks, return_exceptions=True)
             self.cluster.servicesHealth = results


### PR DESCRIPTION
With this fix, all filesystems listed in the configuration of the cluster are reported in the health check report of /status/systems.
It prevents errors when accessing filesystems that are healthy.