### PR TITLE
Fix exception on missing ssh options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.5.1] - OPEN
+
+## [2.5.2] - OPEN
+
+### Added
+
+
+### Changed
+
+
+### Fixed
+
+- Proper handling of non unicode chars in ssh commands output.
+
+
+## [2.5.1]
 
 ### Added
 
@@ -21,8 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Slurm job information is now fetched from both the Slurm DB and the Slurm queue allowing to include ineligible jobs' data.
 - Fixed issue with health check liveness at deployment time.
-
-
 
 
 ## [2.5.0]

--- a/src/lib/ssh_clients/ssh_client.py
+++ b/src/lib/ssh_clients/ssh_client.py
@@ -218,18 +218,21 @@ class SSHClientPool:
         if options and len(options.kwargs["client_certs"]) > 0:
             logger.error("[BEG] Client Certificate debug info:")
             for cert in options.kwargs["client_certs"]:
-                logger.error(f"\tAlgorithm: {cert.get_algorithm()}")
-                logger.error(f"\tPrincipals: {cert.principals}")
-                logger.error(
-                    f"\tPublic key: {cert.key.export_public_key().decode().strip()}"
-                )
-                logger.error(f"\tSerial ID: {cert._serial}")
-                logger.error(
-                    f"\tValid after: {datetime.fromtimestamp(cert._valid_after)}"
-                )
-                logger.error(
-                    f"\tValid before: {datetime.fromtimestamp(cert._valid_before)}"
-                )
+                if isinstance(cert, asyncssh.SSHCertificate):
+                    logger.error(f"\tAlgorithm: {cert.get_algorithm()}")
+                    logger.error(f"\tPrincipals: {cert.principals}")
+                    logger.error(
+                        f"\tPublic key: {cert.key.export_public_key().decode().strip()}"
+                    )
+                    logger.error(f"\tSerial ID: {cert._serial}")
+                    logger.error(
+                        f"\tValid after: {datetime.fromtimestamp(cert._valid_after)}"
+                    )
+                    logger.error(
+                        f"\tValid before: {datetime.fromtimestamp(cert._valid_before)}"
+                    )
+                else:
+                    logger.error("\tNo valid client certificate found.")
             logger.error("[END] Client Certificate debug info")
 
     @asynccontextmanager
@@ -288,4 +291,4 @@ class SSHClientPool:
             except ProtocolError as e:
                 await self.get_ssh_debug_info(options, e.reason)
 
-                raise SSHConnectionError("Unable to establish SSH connection.") from e
+                raise SSHConnectionError("SSH Protocol Error.") from e

--- a/src/lib/ssh_clients/ssh_client.py
+++ b/src/lib/ssh_clients/ssh_client.py
@@ -78,10 +78,10 @@ class SSHClient:
         try:
             async with asyncio.timeout(self.execute_timeout):
                 command_line = command.get_command()
-                process = await self.conn.create_process(command_line)
+                process = await self.conn.create_process(command_line, encoding=None)
 
                 if stdin:
-                    process.stdin.write(stdin)
+                    process.stdin.write(stdin.encode())
                     process.stdin.write_eof()
 
                 stdout_data, stdout_error = await asyncio.gather(
@@ -100,7 +100,9 @@ class SSHClient:
                 # Log command
                 log_backend_command(command_line, process.exit_status)
                 return command.parse_output(
-                    stdout_data, stdout_error, process.exit_status
+                    stdout_data.decode("utf-8", errors="replace"),
+                    stdout_error.decode("utf-8", errors="replace"),
+                    process.exit_status,
                 )
 
         except TimeoutError as e:

--- a/src/lib/ssh_clients/ssh_client.py
+++ b/src/lib/ssh_clients/ssh_client.py
@@ -7,7 +7,7 @@ import asyncio
 from time import time
 from datetime import datetime
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 import asyncssh
 from asyncssh import (
     ChannelOpenError,
@@ -75,6 +75,7 @@ class SSHClient:
             return exc.partial
 
     async def execute(self, command: BaseCommand, stdin: str = None):
+        process = None
         try:
             async with asyncio.timeout(self.execute_timeout):
                 command_line = command.get_command()
@@ -106,9 +107,10 @@ class SSHClient:
                 )
 
         except TimeoutError as e:
-            process.terminate()
-            process.stdin.write("\x03")
-            process.stdin.write_eof()
+            if process:
+                process.terminate()
+                process.stdin.write("\x03".encode())
+                process.stdin.write_eof()
             raise TimeoutLimitExceeded(
                 "Command execution timeout limit exceeded."
             ) from e
@@ -210,8 +212,8 @@ class SSHClientPool:
 
     async def get_ssh_debug_info(
         self,
-        options: asyncssh.SSHClientConnectionOptions = None,
-        exp_reason: str = None,
+        options: Optional[asyncssh.SSHClientConnectionOptions] = None,
+        exp_reason: Optional[str] = None,
     ):
 
         logger = logging.getLogger("uvicorn.error")

--- a/src/lib/ssh_clients/ssh_client.py
+++ b/src/lib/ssh_clients/ssh_client.py
@@ -207,13 +207,15 @@ class SSHClientPool:
         return options
 
     async def get_ssh_debug_info(
-        self, options: asyncssh.SSHClientConnectionOptions, exp_reason: str
+        self,
+        options: asyncssh.SSHClientConnectionOptions = None,
+        exp_reason: str = None,
     ):
 
         logger = logging.getLogger("uvicorn.error")
 
         logger.error(f"SSH Server Error: {exp_reason}")
-        if len(options.kwargs["client_certs"]) > 0:
+        if options and len(options.kwargs["client_certs"]) > 0:
             logger.error("[BEG] Client Certificate debug info:")
             for cert in options.kwargs["client_certs"]:
                 logger.error(f"\tAlgorithm: {cert.get_algorithm()}")
@@ -235,7 +237,9 @@ class SSHClientPool:
         client: SSHClient = None
 
         async with SSHClientPool.lock:
+            options = None
             try:
+
                 if username in self.clients:
                     client = self.clients[username]
                     if client.is_closed():

--- a/tests/filesystem_ops_test.py
+++ b/tests/filesystem_ops_test.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from importlib import resources as impresources
+import re
 from firecrest.filesystem.ops.models import File
 from tests import mocked_ssh_outputs
 import pytest
@@ -15,7 +16,7 @@ from tests.mock_ssh_client import MockedCommand
 def load_ssh_output(file: str):
     output_file = impresources.files(mocked_ssh_outputs) / file
     with output_file.open("rb") as output:
-        return json.load(output)
+        return json.load(output, strict=False)
 
 
 @pytest.fixture(scope="module")
@@ -49,6 +50,11 @@ def mocked_ssh_file_output():
 
 
 @pytest.fixture(scope="module")
+def mocked_ssh_file_non_unicode_output():
+    return load_ssh_output("ssh_file_command_with_non_unicode_char.json")
+
+
+@pytest.fixture(scope="module")
 def mocked_ssh_head_output():
     return load_ssh_output("ssh_head_command.json")
 
@@ -61,6 +67,7 @@ def mocked_ssh_dd_output():
 @pytest.fixture(scope="module")
 def mocked_ssh_dd_with_size_output():
     return load_ssh_output("ssh_dd_command_with_size.json")
+
 
 @pytest.fixture(scope="module")
 def mocked_ssh_tail_output():
@@ -289,6 +296,24 @@ async def test_file_command(client, ssh_client, mocked_ssh_file_output):
         assert response.json()["output"] == mocked_ssh_file_output["stdout"]
 
 
+async def test_file_no_unicode_command(
+    client, ssh_client, mocked_ssh_file_non_unicode_output
+):
+
+    async with ssh_client.mocked_output(
+        [MockedCommand(**mocked_ssh_file_non_unicode_output)]
+    ):
+
+        response = client.get(
+            "/filesystem/cluster-slurm-ssh/ops/file?path={path}".format(
+                path="/home/README.md"
+            )
+        )
+        assert response.status_code == 200
+        assert response.json() is not None
+        assert response.json()["output"] == mocked_ssh_file_non_unicode_output["stdout"]
+
+
 async def test_dd_command(client, ssh_client, mocked_ssh_dd_output):
 
     async with ssh_client.mocked_output([MockedCommand(**mocked_ssh_dd_output)]):
@@ -302,9 +327,12 @@ async def test_dd_command(client, ssh_client, mocked_ssh_dd_output):
         assert response.json() is not None
         assert response.json()["output"] == mocked_ssh_dd_output["stdout"]
 
+
 async def test_dd_command_with_size(client, ssh_client, mocked_ssh_dd_with_size_output):
 
-    async with ssh_client.mocked_output([MockedCommand(**mocked_ssh_dd_with_size_output)]):
+    async with ssh_client.mocked_output(
+        [MockedCommand(**mocked_ssh_dd_with_size_output)]
+    ):
 
         response = client.get(
             "/filesystem/cluster-slurm-ssh/ops/view?path={path}&size={size}".format(
@@ -464,7 +492,9 @@ async def test_tar_compress_command(client, ssh_client, mocked_ssh_tar_output):
         assert response.status_code == 204
 
 
-async def test_tar_compress_with_pattern_command(client, ssh_client, mocked_ssh_tar_output):
+async def test_tar_compress_with_pattern_command(
+    client, ssh_client, mocked_ssh_tar_output
+):
 
     async with ssh_client.mocked_output([MockedCommand(**mocked_ssh_tar_output)]):
 
@@ -473,7 +503,7 @@ async def test_tar_compress_with_pattern_command(client, ssh_client, mocked_ssh_
             json={
                 "source_path": "/home/files/",
                 "target_path": "/home/compressed.tar.gz",
-                "match_pattern": "./[ab].*\\.txt"
+                "match_pattern": "./[ab].*\\.txt",
             },
         )
         assert response.status_code == 204

--- a/tests/mocked_ssh_outputs/ssh_file_command_with_non_unicode_char.json
+++ b/tests/mocked_ssh_outputs/ssh_file_command_with_non_unicode_char.json
@@ -1,0 +1,7 @@
+{
+    "stdout": "Unicode text, non unicode text in brackets []",
+    "stderr": "",
+    "exit_code": 0,
+    "command":"file -b -- '/home/README.md'"
+}
+


### PR DESCRIPTION
Fixes various SSH related issues:

- Allows reading non-UTF-8 files 
- Improved error message related to SSH issues
- SSH cert debugging does not crash if cert is missing