### PR TITLE
Unified subsystem names enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Unified name for subsystems probing and health status.
+
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Unified name for subsystems probing and health status.
+- Unified names for subsystems probing and health status: probing key `filesystems` was renamed to `filesystem` (the old lable is deprecated but still valid).
 
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Unified names for subsystems probing and health status: probing key `filesystems` was renamed to `filesystem` (the old lable is deprecated but still valid).
+- Unified names for subsystems probing and health status: probing key `filesystems` was renamed to `filesystem` (the old label is deprecated but still valid).
 
 
 ### Fixed

--- a/build/demo-launcher/src/launcher/f7t-api-config.demo-env.yaml
+++ b/build/demo-launcher/src/launcher/f7t-api-config.demo-env.yaml
@@ -42,7 +42,7 @@ clusters:
         timeout: 10
       scheduler:
         timeout: 10
-      filesystems:
+      filesystem:
         timeout: 10        
   file_systems:
     - path: '/users'

--- a/build/helm/firecrest-api/values.yaml
+++ b/build/helm/firecrest-api/values.yaml
@@ -250,7 +250,7 @@ firecrest:
         scheduler:
           ## timeout: max time (in seconds) allowed per check
           timeout: 10
-        filesystems:
+        filesystem:
           ## timeout: max time (in seconds) allowed per check
           timeout: 10
 

--- a/docs/setup/arch/health_checks/README.md
+++ b/docs/setup/arch/health_checks/README.md
@@ -26,7 +26,7 @@ Health check execution is configured through the `probing` section of the cluste
         timeout: 10
       scheduler:
         timeout: 20
-      filesystems:
+      filesystem:
         timeout: 10
     ```
 

--- a/f7t-api-config.local-env-tests.yaml
+++ b/f7t-api-config.local-env-tests.yaml
@@ -29,7 +29,7 @@ clusters:
     services:
       scheduler:
         timeout: 5
-      filesystems:
+      filesystem:
         timeout: 5
       storage:
         timeout: 20
@@ -74,7 +74,7 @@ clusters:
     services:
       ssh:
         timeout: 10
-      filesystems:
+      filesystem:
         timeout: 10
       storage:
         timeout: 20
@@ -119,7 +119,7 @@ clusters:
     services:
       ssh:
         timeout: 10
-      filesystems:
+      filesystem:
         timeout: 10
       storage:
         timeout: 20

--- a/f7t-api-config.local-env.yaml
+++ b/f7t-api-config.local-env.yaml
@@ -49,7 +49,7 @@ clusters:
     services:
       scheduler:
         timeout: 20
-      filesystems:
+      filesystem:
         timeout: 20
       ssh:
         timeout: 5
@@ -97,7 +97,7 @@ clusters:
     services:
       ssh:
         timeout: 5
-      filesystems:
+      filesystem:
         timeout: 5
       scheduler:
         timeout: 5
@@ -153,7 +153,7 @@ clusters:
         timeout: 10
       scheduler:
         timeout: 20
-      filesystems:
+      filesystem:
         timeout: 10
       storage:
         timeout: 20

--- a/src/firecrest/config.py
+++ b/src/firecrest/config.py
@@ -106,6 +106,25 @@ class SchedulerConnectionMode(str, Enum):
     ssh = "ssh"
 
 
+class BackendServiceType(str, Enum):
+    """Types of services that can be health-checked."""
+
+    storage = "storage"
+    filesystem = "filesystem"
+    ssh = "ssh"
+    scheduler = "scheduler"
+
+    # Special value used by healtch chercker to identify exceptions, not a real service type
+    exception = "exception"
+
+    # Backward compatibility for old value, to be removed in future versions
+    @classmethod
+    def _missing_(cls, value):
+        if value == "filesystems":
+            return cls.filesystem
+        return None
+
+
 class Scheduler(CamelModel):
     """Cluster job scheduler configuration."""
 
@@ -165,20 +184,10 @@ class ServiceAccount(CamelModel):
     )
 
 
-class HealthCheckType(str, Enum):
-    """Types of services that can be health-checked."""
-
-    scheduler = "scheduler"
-    filesystem = "filesystem"
-    ssh = "ssh"
-    s3 = "s3"
-    exception = "exception"
-
-
 class BaseServiceHealth(CamelModel):
     """Base health status structure for services."""
 
-    service_type: HealthCheckType = Field(
+    service_type: BackendServiceType = Field(
         ..., description="Type of the service being checked."
     )
     last_checked: Optional[datetime] = Field(
@@ -241,7 +250,7 @@ class ProbingService(CamelModel):
 class ProbingServices(CamelModel):
     """Health check interval and list of services."""
 
-    services: Optional[dict[str, ProbingService]] = Field(
+    services: Optional[dict[BackendServiceType, ProbingService]] = Field(
         None, description="Services to be checked."
     )
     interval_check: int = Field(

--- a/src/firecrest/config.py
+++ b/src/firecrest/config.py
@@ -114,7 +114,7 @@ class BackendServiceType(str, Enum):
     ssh = "ssh"
     scheduler = "scheduler"
 
-    # Special value used by healtch chercker to identify exceptions, not a real service type
+    # Special value used by the health checker to identify exceptions; not a real service type.
     exception = "exception"
 
     # Backward compatibility for old value, to be removed in future versions

--- a/src/firecrest/config.py
+++ b/src/firecrest/config.py
@@ -109,7 +109,7 @@ class SchedulerConnectionMode(str, Enum):
 class BackendServiceType(str, Enum):
     """Types of services that can be health-checked."""
 
-    storage = "storage"
+    external_storage = "s3"  # To be renamed to `external_storage` from version 2.6.0
     filesystem = "filesystem"
     ssh = "ssh"
     scheduler = "scheduler"
@@ -117,11 +117,13 @@ class BackendServiceType(str, Enum):
     # Special value used by healtch chercker to identify exceptions, not a real service type
     exception = "exception"
 
-    # Backward compatibility for old value, to be removed in future versions
+    # Backward and forward compatibility to be removed from version 2.6.0
     @classmethod
     def _missing_(cls, value):
         if value == "filesystems":
             return cls.filesystem
+        if value == "storage":
+            return cls.external_storage
         return None
 
 

--- a/src/firecrest/dependencies.py
+++ b/src/firecrest/dependencies.py
@@ -13,7 +13,7 @@ from botocore.handlers import validate_bucket_name
 from firecrest.config import (
     DataTransferType,
     HPCCluster,
-    HealthCheckType,
+    BackendServiceType,
     S3DataTransfer,
     SSHKeysServiceType,
     SchedulerType,
@@ -96,7 +96,7 @@ class APIAuthDependency(AuthDependency):
 
 
 class ServiceAvailabilityDependency:
-    def __init__(self, service_type: HealthCheckType, ignore_health: bool = False):
+    def __init__(self, service_type: BackendServiceType, ignore_health: bool = False):
         self.ignore_health = ignore_health
         self.service_type = service_type
 
@@ -192,11 +192,11 @@ class ServiceAvailabilityDependency:
             )
             # Check health of requested system
             if not self.ignore_health and system.probing.services:
-                if self.service_type == HealthCheckType.filesystem:
+                if self.service_type == BackendServiceType.filesystem:
                     self.__file_system_health(system, request)
-                if self.service_type == HealthCheckType.scheduler:
+                if self.service_type == BackendServiceType.scheduler:
                     self.__scheduler_health(system)
-                if self.service_type == HealthCheckType.ssh:
+                if self.service_type == BackendServiceType.ssh:
                     self.__ssh_health(system)
 
             return system
@@ -247,7 +247,7 @@ class SSHClientDependency:
 
     async def __call__(self, system_name: str):
         system = ServiceAvailabilityDependency(
-            service_type=HealthCheckType.ssh, ignore_health=self.ignore_health
+            service_type=BackendServiceType.ssh, ignore_health=self.ignore_health
         )(system_name=system_name)
 
         async with SSHClientDependency.lock:
@@ -302,7 +302,7 @@ class SchedulerClientDependency:
         system_name: str,
     ):
         system = ServiceAvailabilityDependency(
-            service_type=HealthCheckType.scheduler, ignore_health=self.ignore_health
+            service_type=BackendServiceType.scheduler, ignore_health=self.ignore_health
         )(system_name=system_name)
 
         match system.scheduler.type:
@@ -372,9 +372,9 @@ class DataTransferDependency:
         scheduler_client = await self._get_scheduler_client(system_name)
         ssh_client = await self._get_ssh_client(system_name)
 
-        system = ServiceAvailabilityDependency(service_type=HealthCheckType.scheduler)(
-            system_name=system_name
-        )
+        system = ServiceAvailabilityDependency(
+            service_type=BackendServiceType.scheduler
+        )(system_name=system_name)
         work_dir = next(
             iter([fs.path for fs in system.file_systems if fs.default_work_dir]),
             None,

--- a/src/firecrest/filesystem/ops/router.py
+++ b/src/firecrest/filesystem/ops/router.py
@@ -17,7 +17,7 @@ from typing import Any, Annotated
 from base64 import b64decode, b64encode
 
 # configs
-from firecrest.config import HPCCluster, HealthCheckType
+from firecrest.config import HPCCluster, BackendServiceType
 from firecrest.filesystem.ops.commands.tar_command import TarCommand
 
 # dependencies
@@ -49,7 +49,6 @@ from firecrest.filesystem.ops.commands.chmod_command import ChmodCommand
 from firecrest.filesystem.ops.commands.chown_command import ChownCommand
 from firecrest.filesystem.ops.commands.symlink_command import SymlinkCommand
 
-
 # models
 from firecrest.filesystem.ops.models import (
     GetDirectoryLsResponse,
@@ -70,7 +69,6 @@ from firecrest.filesystem.ops.models import (
     PostFileSymlinkRequest,
     PostFileSymlinkResponse,
 )
-
 
 router = create_router(
     prefix="/{system_name}/ops",
@@ -94,7 +92,7 @@ async def put_chmod(
         Depends(SSHClientDependency()),
     ],
     system: HPCCluster = Depends(
-        ServiceAvailabilityDependency(service_type=HealthCheckType.filesystem),
+        ServiceAvailabilityDependency(service_type=BackendServiceType.filesystem),
         use_cache=False,
     ),
 ):
@@ -127,7 +125,7 @@ async def put_chown(
         Depends(SSHClientDependency()),
     ],
     system: HPCCluster = Depends(
-        ServiceAvailabilityDependency(service_type=HealthCheckType.filesystem),
+        ServiceAvailabilityDependency(service_type=BackendServiceType.filesystem),
         use_cache=False,
     ),
 ):
@@ -162,7 +160,7 @@ async def get_ls(
         Depends(SSHClientDependency()),
     ],
     system: HPCCluster = Depends(
-        ServiceAvailabilityDependency(service_type=HealthCheckType.filesystem),
+        ServiceAvailabilityDependency(service_type=BackendServiceType.filesystem),
         use_cache=False,
     ),
     show_hidden: Annotated[
@@ -212,7 +210,7 @@ async def get_head(
         Depends(SSHClientDependency()),
     ],
     system: HPCCluster = Depends(
-        ServiceAvailabilityDependency(service_type=HealthCheckType.filesystem),
+        ServiceAvailabilityDependency(service_type=BackendServiceType.filesystem),
         use_cache=False,
     ),
     # TODO Should we allow bytes and lines to be strings? The head allows the following:
@@ -294,7 +292,7 @@ async def get_view(
         Depends(SSHClientDependency()),
     ],
     system: HPCCluster = Depends(
-        ServiceAvailabilityDependency(service_type=HealthCheckType.filesystem),
+        ServiceAvailabilityDependency(service_type=BackendServiceType.filesystem),
         use_cache=False,
     ),
     size: Annotated[
@@ -362,7 +360,7 @@ async def get_tail(
         Depends(SSHClientDependency()),
     ],
     system: HPCCluster = Depends(
-        ServiceAvailabilityDependency(service_type=HealthCheckType.filesystem),
+        ServiceAvailabilityDependency(service_type=BackendServiceType.filesystem),
         use_cache=False,
     ),
     file_bytes: Annotated[
@@ -439,7 +437,7 @@ async def get_checksum(
     ],
     path: Annotated[str, Query(description="Target system")],
     system: HPCCluster = Depends(
-        ServiceAvailabilityDependency(service_type=HealthCheckType.filesystem),
+        ServiceAvailabilityDependency(service_type=BackendServiceType.filesystem),
         use_cache=False,
     ),
 ) -> Any:
@@ -469,7 +467,7 @@ async def get_file(
     ],
     path: Annotated[str, Query(description="A file or folder path")],
     system: HPCCluster = Depends(
-        ServiceAvailabilityDependency(service_type=HealthCheckType.filesystem),
+        ServiceAvailabilityDependency(service_type=BackendServiceType.filesystem),
         use_cache=False,
     ),
 ) -> Any:
@@ -496,7 +494,7 @@ async def get_stat(
     ],
     path: Annotated[str, Query(description="A file or folder path")],
     system: HPCCluster = Depends(
-        ServiceAvailabilityDependency(service_type=HealthCheckType.filesystem),
+        ServiceAvailabilityDependency(service_type=BackendServiceType.filesystem),
         use_cache=False,
     ),
     dereference: Annotated[bool, Query(description="Follow symbolic links")] = False,
@@ -525,7 +523,7 @@ async def delete_rm(
         Depends(SSHClientDependency()),
     ],
     system: HPCCluster = Depends(
-        ServiceAvailabilityDependency(service_type=HealthCheckType.filesystem),
+        ServiceAvailabilityDependency(service_type=BackendServiceType.filesystem),
         use_cache=False,
     ),
 ) -> None:
@@ -552,7 +550,7 @@ async def post_mkdir(
         Depends(SSHClientDependency()),
     ],
     system: HPCCluster = Depends(
-        ServiceAvailabilityDependency(service_type=HealthCheckType.filesystem),
+        ServiceAvailabilityDependency(service_type=BackendServiceType.filesystem),
         use_cache=False,
     ),
 ) -> None:
@@ -584,7 +582,7 @@ async def post_symlink(
         Depends(SSHClientDependency()),
     ],
     system: HPCCluster = Depends(
-        ServiceAvailabilityDependency(service_type=HealthCheckType.filesystem),
+        ServiceAvailabilityDependency(service_type=BackendServiceType.filesystem),
         use_cache=False,
     ),
 ) -> Any:
@@ -615,7 +613,7 @@ async def get_download(
     ],
     path: Annotated[str, Query(description="A file to download")],
     system: HPCCluster = Depends(
-        ServiceAvailabilityDependency(service_type=HealthCheckType.filesystem),
+        ServiceAvailabilityDependency(service_type=BackendServiceType.filesystem),
         use_cache=False,
     ),
 ) -> Any:
@@ -654,7 +652,7 @@ async def post_upload(
     ],
     file: UploadFile = File(description="File to be uploaded as `multipart/form-data`"),
     system: HPCCluster = Depends(
-        ServiceAvailabilityDependency(service_type=HealthCheckType.filesystem),
+        ServiceAvailabilityDependency(service_type=BackendServiceType.filesystem),
         use_cache=False,
     ),
 ) -> Any:
@@ -701,7 +699,7 @@ async def post_compress(
         Depends(SSHClientDependency()),
     ],
     system: HPCCluster = Depends(
-        ServiceAvailabilityDependency(service_type=HealthCheckType.filesystem),
+        ServiceAvailabilityDependency(service_type=BackendServiceType.filesystem),
         use_cache=False,
     ),
 ) -> Any:
@@ -737,7 +735,7 @@ async def post_extract(
         Depends(SSHClientDependency()),
     ],
     system: HPCCluster = Depends(
-        ServiceAvailabilityDependency(service_type=HealthCheckType.filesystem),
+        ServiceAvailabilityDependency(service_type=BackendServiceType.filesystem),
         use_cache=False,
     ),
 ) -> Any:

--- a/src/firecrest/filesystem/transfer/router.py
+++ b/src/firecrest/filesystem/transfer/router.py
@@ -10,9 +10,8 @@ from typing import Annotated, Any, List, Optional
 from importlib import resources as imp_resources
 from jinja2 import Environment, FileSystemLoader
 
-
 # plugins
-from firecrest.config import HPCCluster, HealthCheckType
+from firecrest.config import HPCCluster, BackendServiceType
 
 # storage
 from firecrest.filesystem.transfer import scripts
@@ -53,7 +52,6 @@ from firecrest.filesystem.transfer.models import (
     ExtractRequest,
     ExtractResponse,
 )
-
 
 router = create_router(
     prefix="/{system_name}/transfer",
@@ -122,7 +120,7 @@ async def post_upload(
     upload_request: PostFileUploadRequest,
     system_name: Annotated[str, Path(description="Target system")],
     system: HPCCluster = Depends(
-        ServiceAvailabilityDependency(service_type=HealthCheckType.scheduler),
+        ServiceAvailabilityDependency(service_type=BackendServiceType.scheduler),
         use_cache=False,
     ),
     datatransfer=Depends(DataTransferDependency()),
@@ -172,7 +170,7 @@ async def post_download(
     download_request: PostFileDownloadRequest,
     system_name: Annotated[str, Path(description="Target system")],
     system: HPCCluster = Depends(
-        ServiceAvailabilityDependency(service_type=HealthCheckType.scheduler),
+        ServiceAvailabilityDependency(service_type=BackendServiceType.scheduler),
         use_cache=False,
     ),
     datatransfer=Depends(DataTransferDependency()),
@@ -222,7 +220,7 @@ async def move_mv(
     system_name: Annotated[str, Path(description="System where the jobs are running")],
     scheduler_client: SlurmRestClient = Depends(SchedulerClientDependency()),
     system: HPCCluster = Depends(
-        ServiceAvailabilityDependency(service_type=HealthCheckType.filesystem),
+        ServiceAvailabilityDependency(service_type=BackendServiceType.filesystem),
         use_cache=False,
     ),
 ) -> Any:
@@ -280,7 +278,7 @@ async def post_cp(
     system_name: Annotated[str, Path(description="System where the jobs are running")],
     scheduler_client: SlurmRestClient = Depends(SchedulerClientDependency()),
     system: HPCCluster = Depends(
-        ServiceAvailabilityDependency(service_type=HealthCheckType.filesystem),
+        ServiceAvailabilityDependency(service_type=BackendServiceType.filesystem),
         use_cache=False,
     ),
 ) -> Any:
@@ -342,7 +340,7 @@ async def delete_rm(
     scheduler_client: SlurmRestClient = Depends(SchedulerClientDependency()),
     account: Optional[str] = None,
     system: HPCCluster = Depends(
-        ServiceAvailabilityDependency(service_type=HealthCheckType.filesystem),
+        ServiceAvailabilityDependency(service_type=BackendServiceType.filesystem),
         use_cache=False,
     ),
 ) -> Any:
@@ -399,7 +397,7 @@ async def compress(
     system_name: Annotated[str, Path(description="System where the jobs are running")],
     scheduler_client: SlurmRestClient = Depends(SchedulerClientDependency()),
     system: HPCCluster = Depends(
-        ServiceAvailabilityDependency(service_type=HealthCheckType.filesystem),
+        ServiceAvailabilityDependency(service_type=BackendServiceType.filesystem),
         use_cache=False,
     ),
 ) -> Any:
@@ -484,7 +482,7 @@ async def extract(
     system_name: Annotated[str, Path(description="System where the jobs are running")],
     scheduler_client: SlurmRestClient = Depends(SchedulerClientDependency()),
     system: HPCCluster = Depends(
-        ServiceAvailabilityDependency(service_type=HealthCheckType.filesystem),
+        ServiceAvailabilityDependency(service_type=BackendServiceType.filesystem),
         use_cache=False,
     ),
 ) -> Any:

--- a/src/firecrest/status/health_check/checks/health_check_filesystem.py
+++ b/src/firecrest/status/health_check/checks/health_check_filesystem.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from firecrest.config import (
+    BackendServiceType,
     FilesystemServiceHealth,
     HPCCluster,
 )
@@ -27,7 +28,7 @@ class FilesystemHealthCheck(HealthCheckBase):
             system_name=self.system.name
         )
 
-        health = FilesystemServiceHealth(service_type="filesystem")
+        health = FilesystemServiceHealth(service_type=BackendServiceType.filesystem)
         health.healthy = True
         health.path = self.path
 
@@ -43,7 +44,7 @@ class FilesystemHealthCheck(HealthCheckBase):
         return health
 
     async def handle_error(self, ex: Exception) -> FilesystemServiceHealth:
-        health = FilesystemServiceHealth(service_type="filesystem")
+        health = FilesystemServiceHealth(service_type=BackendServiceType.filesystem)
         health.healthy = False
         health.path = self.path
         health.message = str(ex)

--- a/src/firecrest/status/health_check/checks/health_check_s3.py
+++ b/src/firecrest/status/health_check/checks/health_check_s3.py
@@ -32,7 +32,7 @@ class S3HealthCheck(HealthCheckBase):
 
     async def execute_check(self) -> S3ServiceHealth:
 
-        health = S3ServiceHealth(service_type=BackendServiceType.storage)
+        health = S3ServiceHealth(service_type=BackendServiceType.external_storage)
         health.healthy = True
 
         async with self._get_s3_client(
@@ -46,7 +46,7 @@ class S3HealthCheck(HealthCheckBase):
         return health
 
     async def handle_error(self, ex: Exception) -> S3ServiceHealth:
-        health = S3ServiceHealth(service_type=BackendServiceType.storage)
+        health = S3ServiceHealth(service_type=BackendServiceType.external_storage)
         health.healthy = False
         health.message = str(ex)
         return health

--- a/src/firecrest/status/health_check/checks/health_check_s3.py
+++ b/src/firecrest/status/health_check/checks/health_check_s3.py
@@ -5,6 +5,7 @@
 
 from firecrest.config import (
     BaseDataTransfer,
+    BackendServiceType,
     S3ServiceHealth,
 )
 from aiobotocore.session import get_session
@@ -31,7 +32,7 @@ class S3HealthCheck(HealthCheckBase):
 
     async def execute_check(self) -> S3ServiceHealth:
 
-        health = S3ServiceHealth(service_type="s3")
+        health = S3ServiceHealth(service_type=BackendServiceType.storage)
         health.healthy = True
 
         async with self._get_s3_client(
@@ -45,7 +46,7 @@ class S3HealthCheck(HealthCheckBase):
         return health
 
     async def handle_error(self, ex: Exception) -> S3ServiceHealth:
-        health = S3ServiceHealth(service_type="s3")
+        health = S3ServiceHealth(service_type=BackendServiceType.storage)
         health.healthy = False
         health.message = str(ex)
         return health

--- a/src/firecrest/status/health_check/checks/health_check_scheduler.py
+++ b/src/firecrest/status/health_check/checks/health_check_scheduler.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from typing import List
-from firecrest.config import HPCCluster, SchedulerServiceHealth
+from firecrest.config import HPCCluster, BackendServiceType, SchedulerServiceHealth
 from firecrest.dependencies import SchedulerClientDependency
 from firecrest.status.health_check.checks.health_check_base import HealthCheckBase
 from lib.scheduler_clients.models import SchedPing
@@ -24,7 +24,7 @@ class SchedulerHealthCheck(HealthCheckBase):
             system_name=self.system.name
         )
 
-        health = SchedulerServiceHealth(service_type="scheduler")
+        health = SchedulerServiceHealth(service_type=BackendServiceType.scheduler)
         pings: List[SchedPing] = await self.scheduler_client.ping(
             self.auth.username, self.token["access_token"]
         )
@@ -36,7 +36,7 @@ class SchedulerHealthCheck(HealthCheckBase):
         error_message = f"{ex.__class__.__name__}"
         if len(str(ex)) > 0:
             error_message = f"{ex.__class__.__name__}: {str(ex)}"
-        health = SchedulerServiceHealth(service_type="scheduler")
+        health = SchedulerServiceHealth(service_type=BackendServiceType.scheduler)
         health.healthy = False
         health.message = error_message
         return health

--- a/src/firecrest/status/health_check/checks/health_check_ssh.py
+++ b/src/firecrest/status/health_check/checks/health_check_ssh.py
@@ -3,7 +3,7 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
-from firecrest.config import HPCCluster, SSHServiceHealth
+from firecrest.config import HPCCluster, BackendServiceType, SSHServiceHealth
 from firecrest.dependencies import SSHClientDependency
 from firecrest.status.health_check.checks.health_check_base import HealthCheckBase
 from firecrest.status.health_check.checks.true_command import TrueCommand
@@ -23,7 +23,7 @@ class SSHHealthCheck(HealthCheckBase):
             system_name=self.system.name
         )
 
-        health = SSHServiceHealth(service_type="ssh")
+        health = SSHServiceHealth(service_type=BackendServiceType.ssh)
         health.healthy = True
 
         self.ssh_client.execute_timeout = self.timeout
@@ -37,7 +37,7 @@ class SSHHealthCheck(HealthCheckBase):
         return health
 
     async def handle_error(self, ex: Exception) -> SSHServiceHealth:
-        health = SSHServiceHealth(service_type="ssh")
+        health = SSHServiceHealth(service_type=BackendServiceType.ssh)
         health.healthy = False
         health.message = str(ex)
         return health

--- a/src/firecrest/status/health_check/health_checker_cluster.py
+++ b/src/firecrest/status/health_check/health_checker_cluster.py
@@ -5,7 +5,12 @@
 
 import asyncio
 from datetime import datetime, timezone
-from firecrest.config import HPCCluster, HealthCheckException, DataTransferType
+from firecrest.config import (
+    BackendServiceType,
+    HPCCluster,
+    HealthCheckException,
+    DataTransferType,
+)
 
 from firecrest.status.health_check.checks.health_check_filesystem import (
     FilesystemHealthCheck,
@@ -61,41 +66,41 @@ class ClusterHealthChecker:
             if self.cluster.probing.services is not None:
                 services = self.cluster.probing.services
 
-                if "scheduler" in services:
+                if BackendServiceType.scheduler in services:
                     sechedulerCheck = SchedulerHealthCheck(
                         system=self.cluster,
                         auth=auth,
                         token=token,
-                        timeout=services["scheduler"].timeout,
+                        timeout=services[BackendServiceType.scheduler].timeout,
                     )
                     checks += [sechedulerCheck.check()]
 
-                if "ssh" in services:
+                if BackendServiceType.ssh in services:
                     sshCheck = SSHHealthCheck(
                         system=self.cluster,
                         auth=auth,
                         token=token,
-                        timeout=services["ssh"].timeout,
+                        timeout=services[BackendServiceType.ssh].timeout,
                     )
                     checks += [sshCheck.check()]
 
-                if "filesystems" in services:
+                if BackendServiceType.filesystem in services:
                     for filesystem in self.cluster.file_systems:
                         filesystemCheck = FilesystemHealthCheck(
                             system=self.cluster,
                             auth=auth,
                             token=token,
                             path=filesystem.path,
-                            timeout=services["filesystems"].timeout,
+                            timeout=services[BackendServiceType.filesystem].timeout,
                         )
                         checks += [filesystemCheck.check()]
 
-                if "storage" in services:
+                if BackendServiceType.storage in services:
                     match self.cluster.data_operation.data_transfer.service_type:
                         case DataTransferType.s3:
                             s3Check = S3HealthCheck(
                                 data_transfer=self.cluster.data_operation.data_transfer,
-                                timeout=services["storage"].timeout,
+                                timeout=services[BackendServiceType.storage].timeout,
                             )
                             checks += [s3Check.check()]
 

--- a/src/firecrest/status/health_check/health_checker_cluster.py
+++ b/src/firecrest/status/health_check/health_checker_cluster.py
@@ -67,13 +67,13 @@ class ClusterHealthChecker:
                 services = self.cluster.probing.services
 
                 if BackendServiceType.scheduler in services:
-                    sechedulerCheck = SchedulerHealthCheck(
+                    schedulerCheck = SchedulerHealthCheck(
                         system=self.cluster,
                         auth=auth,
                         token=token,
                         timeout=services[BackendServiceType.scheduler].timeout,
                     )
-                    checks += [sechedulerCheck.check()]
+                    checks += [schedulerCheck.check()]
 
                 if BackendServiceType.ssh in services:
                     sshCheck = SSHHealthCheck(

--- a/src/firecrest/status/health_check/health_checker_cluster.py
+++ b/src/firecrest/status/health_check/health_checker_cluster.py
@@ -95,12 +95,14 @@ class ClusterHealthChecker:
                         )
                         checks += [filesystemCheck.check()]
 
-                if BackendServiceType.storage in services:
+                if BackendServiceType.external_storage in services:
                     match self.cluster.data_operation.data_transfer.service_type:
                         case DataTransferType.s3:
                             s3Check = S3HealthCheck(
                                 data_transfer=self.cluster.data_operation.data_transfer,
-                                timeout=services[BackendServiceType.storage].timeout,
+                                timeout=services[
+                                    BackendServiceType.external_storage
+                                ].timeout,
                             )
                             checks += [s3Check.check()]
 

--- a/src/firecrest/status/router.py
+++ b/src/firecrest/status/router.py
@@ -8,7 +8,7 @@ from fastapi import Depends, HTTPException, Path, status
 from typing import Annotated, Any
 
 # configs
-from firecrest.config import HPCCluster, HealthCheckType
+from firecrest.config import HPCCluster, BackendServiceType
 from firecrest.status.commands.id_command import IdCommand
 from firecrest.plugins import settings
 
@@ -169,7 +169,7 @@ async def get_userinfo(
         Depends(SchedulerClientDependency(ignore_health=True)),
     ] = None,
     system: HPCCluster = Depends(
-        ServiceAvailabilityDependency(service_type=HealthCheckType.ssh),
+        ServiceAvailabilityDependency(service_type=BackendServiceType.ssh),
         use_cache=False,
     ),
 ) -> Any:


### PR DESCRIPTION
This PR fixes #206 by introducing a unified service name enum shared between the probing configuration and the health check status.

This change is backwards compatible.