### PR TITLE
Request token for the service account only when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.x.y] - OPEN
 
-## [2.5.2] - OPEN
+### Added
+
+
+### Changed
+
+
+### Fixed
+
+- Only request access token for health check user when needed. This also allows disabling health checks completely, for setups where client credentials authentication is not available.
+
+## [2.5.2]
 
 ### Added
 

--- a/src/firecrest/status/health_check/health_checker_cluster.py
+++ b/src/firecrest/status/health_check/health_checker_cluster.py
@@ -56,15 +56,20 @@ class ClusterHealthChecker:
                 self.cluster.service_account.secret.get_secret_value(),
             )
 
-            token = await client.fetch_token(
-                url=settings.auth.authentication.token_url,
-                grant_type="client_credentials",
-            )
-            auth = self.token_decoder.auth_from_token(token["access_token"])
-
             checks = []
             if self.cluster.probing.services is not None:
                 services = self.cluster.probing.services
+
+                if any(s in services for s in (
+                    BackendServiceType.scheduler,
+                    BackendServiceType.ssh,
+                    BackendServiceType.filesystem)
+                ):
+                    token = await client.fetch_token(
+                        url=settings.auth.authentication.token_url,
+                        grant_type="client_credentials",
+                    )
+                    auth = self.token_decoder.auth_from_token(token["access_token"])
 
                 if BackendServiceType.scheduler in services:
                     schedulerCheck = SchedulerHealthCheck(


### PR DESCRIPTION
This patch modifies the cluster health checker to only request an access token for service user when probing is enabled for a service necessitating it. This allows running FirecREST without a valid client credentials -capable service user.

Service user credentials still need to be specified in the configuration, but the values don't have to be valid.