### PR TITLE
Added token_endpoint_auth_method option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Configuration setting `token_endpoint_auth_method` to authenticate the health-check client following [OIDC client authentication standards](https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication). The default is defined as `client_secret_basic`
+- Configuration setting `token_endpoint_auth_method` to authenticate the health-check client following [OIDC client authentication standards](https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication). Defaults to `client_secret_basic` to match pre-2.5.3 behavior.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.3] - OPEN
 
-## [2.5.2] - OPEN
+### Added
+
+- Configuration setting `token_endpoint_auth_method` to authenticate the health-check client following [OIDC client authentication standards](https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication). By default is defined as `client_secret_post`
+
+### Changed
+
+### Fixed
+
+## [2.5.2]
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Configuration setting `token_endpoint_auth_method` to authenticate the health-check client following [OIDC client authentication standards](https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication). By default is defined as `client_secret_post`
+- Configuration setting `token_endpoint_auth_method` to authenticate the health-check client following [OIDC client authentication standards](https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication). The default is defined as `client_secret_basic`
 
 ### Changed
 

--- a/build/helm/firecrest-api/values.yaml
+++ b/build/helm/firecrest-api/values.yaml
@@ -88,12 +88,12 @@ firecrest:
       ##     - firecrest
       ## scopes: {}
 
-      ## token_endpoint_auth_method: Authentication method for the token endpoint for the Health Check OIDC/OAuth2 client. 
+      ## token_endpoint_auth_method: Authentication method for the token endpoint for the Health Check OIDC/OAuth2 client.
       ## Methods include "client_secret_basic" and "client_secret_post", in the future other types can be added such as: "client_secret_jwt" and "private_key_jwt".
-      ## Default is "client_secret_post".
+      ## Default is "client_secret_basic".
       ## example: 
-      ##   token_endpoint_auth_method: "client_secret_basic"
-      ## token_endpoint_auth_method: "client_secret_post"
+      ##   token_endpoint_auth_method: "client_secret_post"
+      # token_endpoint_auth_method: "client_secret_basic"
 
       ## public_certs: list of public certificate endpoints for IdPs accepted by FirecREST
       ## example:

--- a/build/helm/firecrest-api/values.yaml
+++ b/build/helm/firecrest-api/values.yaml
@@ -88,6 +88,13 @@ firecrest:
       ##     - firecrest
       ## scopes: {}
 
+      ## token_endpoint_auth_method: Authentication method for the token endpoint for the Health Check OIDC/OAuth2 client. 
+      ## Methods include "client_secret_basic" and "client_secret_post", in the future other types can be added such as: "client_secret_jwt" and "private_key_jwt".
+      ## Default is "client_secret_post".
+      ## example: 
+      ##   token_endpoint_auth_method: "client_secret_basic"
+      ## token_endpoint_auth_method: "client_secret_post"
+
       ## public_certs: list of public certificate endpoints for IdPs accepted by FirecREST
       ## example:
       ##   public_certs:

--- a/f7t-api-config.local-env-tests.yaml
+++ b/f7t-api-config.local-env-tests.yaml
@@ -2,7 +2,7 @@ auth:
   authentication:
     scopes:  {}
     tokenUrl:  "http://192.168.240.3:8080/auth/realms/kcrealm/protocol/openid-connect/token"
-    tokenEndpointAuthMethod: "client_secret_basic"
+    tokenEndpointAuthMethod: "client_secret_post"
     publicCerts: []
     usernameClaim: "sub"
 ssh_credentials:

--- a/f7t-api-config.local-env-tests.yaml
+++ b/f7t-api-config.local-env-tests.yaml
@@ -2,9 +2,9 @@ auth:
   authentication:
     scopes:  {}
     tokenUrl:  "http://192.168.240.3:8080/auth/realms/kcrealm/protocol/openid-connect/token"
-    token_endpoint_auth_method: "client_secret_basic"
+    tokenEndpointAuthMethod: "client_secret_basic"
     publicCerts: []
-    username_claim: "sub"
+    usernameClaim: "sub"
 ssh_credentials:
   type: "SSHService"
   url: "http://192.168.240.20:5000"

--- a/f7t-api-config.local-env-tests.yaml
+++ b/f7t-api-config.local-env-tests.yaml
@@ -2,6 +2,7 @@ auth:
   authentication:
     scopes:  {}
     tokenUrl:  "http://192.168.240.3:8080/auth/realms/kcrealm/protocol/openid-connect/token"
+    token_endpoint_auth_method: "client_secret_basic"
     publicCerts: []
     username_claim: "sub"
 ssh_credentials:

--- a/f7t-api-config.local-env.yaml
+++ b/f7t-api-config.local-env.yaml
@@ -6,7 +6,7 @@ auth:
   authentication:
     scopes:  {}
     tokenUrl:  "http://keycloak:8080/auth/realms/kcrealm/protocol/openid-connect/token"
-    # tokenEndpointAuthMethod: "client_secret_post"
+    tokenEndpointAuthMethod: "client_secret_post"
     publicCerts:
         - "http://keycloak:8080/auth/realms/kcrealm/protocol/openid-connect/certs"
     usernameClaim: "sub"

--- a/f7t-api-config.local-env.yaml
+++ b/f7t-api-config.local-env.yaml
@@ -6,10 +6,10 @@ auth:
   authentication:
     scopes:  {}
     tokenUrl:  "http://keycloak:8080/auth/realms/kcrealm/protocol/openid-connect/token"
-    token_endpoint_auth_method: "client_secret_basic"
+    # tokenEndpointAuthMethod: "client_secret_post"
     publicCerts:
         - "http://keycloak:8080/auth/realms/kcrealm/protocol/openid-connect/certs"
-    username_claim: "sub"
+    usernameClaim: "sub"
 #ssh_credentials:
 #  type: "SSHCA"
 #  url: "http://deic-sshca:2280/demoCA"

--- a/f7t-api-config.local-env.yaml
+++ b/f7t-api-config.local-env.yaml
@@ -6,6 +6,7 @@ auth:
   authentication:
     scopes:  {}
     tokenUrl:  "http://keycloak:8080/auth/realms/kcrealm/protocol/openid-connect/token"
+    token_endpoint_auth_method: "client_secret_basic"
     publicCerts:
         - "http://keycloak:8080/auth/realms/kcrealm/protocol/openid-connect/certs"
     username_claim: "sub"

--- a/src/firecrest/status/health_check/health_checker_cluster.py
+++ b/src/firecrest/status/health_check/health_checker_cluster.py
@@ -54,7 +54,7 @@ class ClusterHealthChecker:
             client = AsyncOAuth2Client(
                 self.cluster.service_account.client_id,
                 self.cluster.service_account.secret.get_secret_value(),
-                token_endpoint_auth_method=settings.auth.authentication.token_endpoint_auth_method,
+                token_endpoint_auth_method=settings.auth.authentication.token_endpoint_auth_method.value,
             )
 
             token = await client.fetch_token(

--- a/src/firecrest/status/health_check/health_checker_cluster.py
+++ b/src/firecrest/status/health_check/health_checker_cluster.py
@@ -54,6 +54,7 @@ class ClusterHealthChecker:
             client = AsyncOAuth2Client(
                 self.cluster.service_account.client_id,
                 self.cluster.service_account.secret.get_secret_value(),
+                token_endpoint_auth_method=settings.auth.authentication.token_endpoint_auth_method,
             )
 
             token = await client.fetch_token(

--- a/src/lib/models/config_model.py
+++ b/src/lib/models/config_model.py
@@ -8,6 +8,7 @@ from typing import List, Optional
 
 from pydantic import SecretStr, Field
 from lib.models.base_model import CamelModel
+from lib.models.token_endpoint_auth_method import TokenEndpointAuthMethod
 
 
 class Oidc(CamelModel):
@@ -27,6 +28,15 @@ class Oidc(CamelModel):
             "obtain access tokens for the service account that will do the "
             "health checks."
         ),
+    )
+    token_endpoint_auth_method: Optional[TokenEndpointAuthMethod] = Field(
+        TokenEndpointAuthMethod.client_secret_post,
+        description=(
+            "Authentication method for the token endpoint. This is used to "
+            "specify how the client credentials are sent when fetching the "
+            "token for the health checks."
+        ),
+        nullable=False,
     )
     public_certs: List[str] = Field(
         default_factory=list,

--- a/src/lib/models/config_model.py
+++ b/src/lib/models/config_model.py
@@ -30,13 +30,13 @@ class Oidc(CamelModel):
         ),
     )
     token_endpoint_auth_method: Optional[TokenEndpointAuthMethod] = Field(
-        TokenEndpointAuthMethod.client_secret_post,
+        TokenEndpointAuthMethod.client_secret_basic,
         description=(
             "Authentication method for the token endpoint. This is used to "
             "specify how the client credentials are sent when fetching the "
-            "token for the health checks."
+            "token for the health checks. By default is 'client_secret_basic'"
         ),
-        nullable=False,
+        nullable=True,
     )
     public_certs: List[str] = Field(
         default_factory=list,

--- a/src/lib/models/config_model.py
+++ b/src/lib/models/config_model.py
@@ -29,14 +29,14 @@ class Oidc(CamelModel):
             "health checks."
         ),
     )
-    token_endpoint_auth_method: Optional[TokenEndpointAuthMethod] = Field(
+    token_endpoint_auth_method: TokenEndpointAuthMethod = Field(
         TokenEndpointAuthMethod.client_secret_basic,
         description=(
             "Authentication method for the token endpoint. This is used to "
             "specify how the client credentials are sent when fetching the "
-            "token for the health checks. By default is 'client_secret_basic'"
+            "token for the health checks. Defaults to 'client_secret_basic'."
         ),
-        nullable=True,
+        nullable=False,
     )
     public_certs: List[str] = Field(
         default_factory=list,

--- a/src/lib/models/token_endpoint_auth_method.py
+++ b/src/lib/models/token_endpoint_auth_method.py
@@ -7,5 +7,5 @@ from enum import Enum
 
 
 class TokenEndpointAuthMethod(str, Enum):
-    client_secret_post = "client_secret_post"
-    client_secret_basic = "client_secret_basic"
+    client_secret_post = "client_secret_post"  # noqa: S105 - avoids hardcoded password string, this is a standard OAuth2 authentication method
+    client_secret_basic = "client_secret_basic"  # noqa: S105 - avoids hardcoded password string, this is a standard OAuth2 authentication method

--- a/src/lib/models/token_endpoint_auth_method.py
+++ b/src/lib/models/token_endpoint_auth_method.py
@@ -1,0 +1,11 @@
+# Copyright (c) 2025, ETH Zurich. All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+
+from enum import Enum
+
+
+class TokenEndpointAuthMethod(str, Enum):
+    client_secret_post = "client_secret_post"
+    client_secret_basic = "client_secret_basic"


### PR DESCRIPTION
Added the option `token_endpoint_auth_method` to authenticate clients with methods selected from the settings of FirecREST. This is used only to get access tokens from the health check client.