### PR TITLE
Forward monitoring headers from client requests to ssh keygen backend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -173,10 +173,6 @@ services:
       - ./build/minio:/data:delegated
   ssh-ca:
     image: deic-sshca
-    environment:
-      ENVIRONMENT: development
-      SSH_KEYGEN_URL: http://192.168.240.20:5000
-      YAML_CONFIG_FILE: "/app/config/app-config.yaml"
     depends_on:
       keycloak:
         condition: service_healthy

--- a/f7t-api-config.local-env.yaml
+++ b/f7t-api-config.local-env.yaml
@@ -12,7 +12,7 @@ auth:
     usernameClaim: "sub"
 #ssh_credentials:
 #  type: "SSHCA"
-#  url: "http://deic-sshca:2280/demoCA"
+#  url: "http://192.168.240.22:2280/demoCA"
 #  max_connections: 500
 ssh_credentials:
   type: "SSHStaticKeys"

--- a/src/firecrest/dependencies.py
+++ b/src/firecrest/dependencies.py
@@ -239,7 +239,7 @@ class SSHClientDependency:
                 self.key_provider = SSHKeygenCredentialsProvider(
                     settings.ssh_credentials.url,
                     settings.ssh_credentials.max_connections,
-                    settings.app_version,
+                    app_version=settings.app_version,
                 )
             case SSHKeysServiceType.SSHStaticKeys:
                 self.key_provider = SSHStaticKeysProvider(settings.ssh_credentials.keys)

--- a/src/firecrest/dependencies.py
+++ b/src/firecrest/dependencies.py
@@ -240,6 +240,7 @@ class SSHClientDependency:
                 self.key_provider = SSHKeygenCredentialsProvider(
                     settings.ssh_credentials.url,
                     settings.ssh_credentials.max_connections,
+                    app_version=settings.app_version,
                 )
             case SSHKeysServiceType.SSHStaticKeys:
                 self.key_provider = SSHStaticKeysProvider(settings.ssh_credentials.keys)

--- a/src/firecrest/dependencies.py
+++ b/src/firecrest/dependencies.py
@@ -239,6 +239,7 @@ class SSHClientDependency:
                 self.key_provider = SSHKeygenCredentialsProvider(
                     settings.ssh_credentials.url,
                     settings.ssh_credentials.max_connections,
+                    settings.app_version,
                 )
             case SSHKeysServiceType.SSHStaticKeys:
                 self.key_provider = SSHStaticKeysProvider(settings.ssh_credentials.keys)

--- a/src/firecrest/dependencies.py
+++ b/src/firecrest/dependencies.py
@@ -239,7 +239,6 @@ class SSHClientDependency:
                 self.key_provider = SSHKeygenCredentialsProvider(
                     settings.ssh_credentials.url,
                     settings.ssh_credentials.max_connections,
-                    app_version=settings.app_version,
                 )
             case SSHKeysServiceType.SSHStaticKeys:
                 self.key_provider = SSHStaticKeysProvider(settings.ssh_credentials.keys)

--- a/src/firecrest/dependencies.py
+++ b/src/firecrest/dependencies.py
@@ -234,6 +234,7 @@ class SSHClientDependency:
                 self.key_provider = DeiCSSHCACredentialsProvider(
                     settings.ssh_credentials.url,
                     settings.ssh_credentials.max_connections,
+                    app_version=settings.app_version,
                 )
             case SSHKeysServiceType.SSHService:
                 self.key_provider = SSHKeygenCredentialsProvider(

--- a/src/firecrest/main.py
+++ b/src/firecrest/main.py
@@ -128,6 +128,10 @@ def register_middlewares(app: FastAPI):
     @app.middleware("http")
     async def init_request_vars(request: Request, call_next):
         initial_g = types.SimpleNamespace()
+        initial_g.x_request_id = request.headers.get("x-request-id")
+        initial_g.x_client_type = request.headers.get("x-client-type")
+        initial_g.x_client_name = request.headers.get("x-client-name")
+        initial_g.x_client_version = request.headers.get("x-client-version")
         request_vars.request_global.set(initial_g)
         response = await call_next(request)
         return response

--- a/src/firecrest/main.py
+++ b/src/firecrest/main.py
@@ -131,12 +131,10 @@ async def schedule_tasks(scheduler: AsyncScheduler):
 def register_middlewares(app: FastAPI):
     @app.middleware("http")
     async def init_request_vars(request: Request, call_next):
-        initial_g = types.SimpleNamespace()
-        initial_g.x_request_id = request.headers.get("x-request-id")
-        initial_g.x_client_type = request.headers.get("x-client-type")
-        initial_g.x_client_name = request.headers.get("x-client-name")
-        initial_g.x_client_version = request.headers.get("x-client-version")
-        request_vars.request_global.set(initial_g)
+        # A fresh namespace per request, bound in this async context, so
+        # per-request state (e.g. auth in api_auth_helper.py) never leaks
+        # across concurrent requests sharing the contextvar's default.
+        request_vars.request_global.set(types.SimpleNamespace())
         response = await call_next(request)
         return response
 

--- a/src/lib/ssh_clients/deic_sshca_credentials_provider.py
+++ b/src/lib/ssh_clients/deic_sshca_credentials_provider.py
@@ -12,12 +12,29 @@ from typing import Optional
 from cryptography.hazmat.primitives.asymmetric import ed25519
 from cryptography.hazmat.primitives import serialization
 
+from starlette_context import context
+from starlette_context.header_keys import HeaderKeys
 
 # exceptions
 from lib.exceptions import SSHServiceError
 from lib.ssh_clients.ssh_credentials_provider import SSHCredentialsProvider
 
 SIZE_POOL_AIOHTTP = 100
+
+
+def _ssh_service_headers(app_version: str) -> dict:
+    headers = {
+        "Content-Type": "application/json",
+        "x-client-type": "api",
+        "x-client-name": "firecrest",
+        "x-client-version": app_version,
+    }
+    if context.exists():
+        if HeaderKeys.request_id in context:
+            headers["x-request-id"] = context[HeaderKeys.request_id]
+        if HeaderKeys.correlation_id in context:
+            headers["x-trace-id"] = context[HeaderKeys.correlation_id]
+    return headers
 
 
 class DeiCSSHCACredentialsProvider(SSHCredentialsProvider):
@@ -43,8 +60,9 @@ class DeiCSSHCACredentialsProvider(SSHCredentialsProvider):
             await cls.aiohttp_client.close()
             cls.aiohttp_client = None
 
-    def __init__(self, ssh_keygen_url: str, max_connections: int = 100):
+    def __init__(self, ssh_keygen_url: str, max_connections: int = 100, *, app_version: str):
         self.ssh_keygen_url = ssh_keygen_url
+        self.app_version = app_version
         DeiCSSHCACredentialsProvider.max_connections = max_connections
 
     def genkeys(self):
@@ -70,6 +88,7 @@ class DeiCSSHCACredentialsProvider(SSHCredentialsProvider):
     ) -> SSHCredentialsProvider.SSHCredentials:
 
         client = await self.get_aiohttp_client()
+        headers = _ssh_service_headers(self.app_version)
 
         private, public = self.genkeys()
         post_data = {"PublicKey": public, "OTT": jwt_token}
@@ -77,6 +96,7 @@ class DeiCSSHCACredentialsProvider(SSHCredentialsProvider):
         async with client.post(
             url=f"{self.ssh_keygen_url}/sign",
             data=json.dumps(post_data),
+            headers=headers,
         ) as response:
             if response.status != status.HTTP_200_OK:
                 message = await response.text()

--- a/src/lib/ssh_clients/ssh_keygen_credentials_provider.py
+++ b/src/lib/ssh_clients/ssh_keygen_credentials_provider.py
@@ -56,7 +56,7 @@ class SSHKeygenCredentialsProvider(SSHCredentialsProvider):
             await cls.aiohttp_client.close()
             cls.aiohttp_client = None
 
-    def __init__(self, ssh_keygen_url: str, max_connections: int = 100, app_version: str = ""):
+    def __init__(self, ssh_keygen_url: str, max_connections: int = 100, *, app_version: str):
         self.ssh_keygen_url = ssh_keygen_url
         self.app_version = app_version
         SSHKeygenCredentialsProvider.max_connections = max_connections

--- a/src/lib/ssh_clients/ssh_keygen_credentials_provider.py
+++ b/src/lib/ssh_clients/ssh_keygen_credentials_provider.py
@@ -58,13 +58,14 @@ class SSHKeygenCredentialsProvider(SSHCredentialsProvider):
             await cls.aiohttp_client.close()
             cls.aiohttp_client = None
 
-    def __init__(self, ssh_keygen_url: str, max_connections: int = 100):
+    def __init__(self, ssh_keygen_url: str, max_connections: int = 100, *, app_version: str):
         self.ssh_keygen_url = ssh_keygen_url
+        self.app_version = app_version
         SSHKeygenCredentialsProvider.max_connections = max_connections
 
     async def get_credentials(self, username: str, jwt_token: str):
         client = await self.get_aiohttp_client()
-        headers = _ssh_service_headers(jwt_token)
+        headers = _ssh_service_headers(jwt_token, self.app_version)
 
         post_data = {
             "duration": "1min",

--- a/src/lib/ssh_clients/ssh_keygen_credentials_provider.py
+++ b/src/lib/ssh_clients/ssh_keygen_credentials_provider.py
@@ -13,15 +13,24 @@ from typing import Optional
 # exceptions
 from lib.exceptions import SSHServiceError
 from lib.ssh_clients.ssh_credentials_provider import SSHCredentialsProvider
+from lib.request_vars import g
 
 SIZE_POOL_AIOHTTP = 100
 
 
-def _ssh_service_headers(jwt_token: str):
-    return {
+def _ssh_service_headers(jwt_token: str, app_version: str) -> dict:
+    ctx = g()
+    headers = {
         "Content-Type": "application/json",
         "Authorization": f"Bearer {jwt_token}",
+        "x-client-type": getattr(ctx, "x_client_type", None) or "api",
+        "x-client-name": getattr(ctx, "x_client_name", None) or "firecrest",
+        "x-client-version": getattr(ctx, "x_client_version", None) or app_version,
     }
+    x_request_id = getattr(ctx, "x_request_id", None)
+    if x_request_id:
+        headers["x-request-id"] = x_request_id
+    return headers
 
 
 class SSHKeygenCredentialsProvider(SSHCredentialsProvider):
@@ -47,13 +56,14 @@ class SSHKeygenCredentialsProvider(SSHCredentialsProvider):
             await cls.aiohttp_client.close()
             cls.aiohttp_client = None
 
-    def __init__(self, ssh_keygen_url: str, max_connections: int = 100):
+    def __init__(self, ssh_keygen_url: str, max_connections: int = 100, app_version: str = ""):
         self.ssh_keygen_url = ssh_keygen_url
+        self.app_version = app_version
         SSHKeygenCredentialsProvider.max_connections = max_connections
 
     async def get_credentials(self, username: str, jwt_token: str):
         client = await self.get_aiohttp_client()
-        headers = _ssh_service_headers(jwt_token)
+        headers = _ssh_service_headers(jwt_token, self.app_version)
 
         post_data = {
             "duration": "1min",

--- a/src/lib/ssh_clients/ssh_keygen_credentials_provider.py
+++ b/src/lib/ssh_clients/ssh_keygen_credentials_provider.py
@@ -18,15 +18,17 @@ from lib.request_vars import g
 SIZE_POOL_AIOHTTP = 100
 
 
-def _ssh_service_headers(jwt_token: str, app_version: str) -> dict:
+def _ssh_service_headers(jwt_token: str) -> dict:
     ctx = g()
     headers = {
         "Content-Type": "application/json",
         "Authorization": f"Bearer {jwt_token}",
         "x-client-type": getattr(ctx, "x_client_type", None) or "api",
         "x-client-name": getattr(ctx, "x_client_name", None) or "firecrest",
-        "x-client-version": getattr(ctx, "x_client_version", None) or app_version,
     }
+    x_client_version = getattr(ctx, "x_client_version", None)
+    if x_client_version:
+        headers["x-client-version"] = x_client_version
     x_request_id = getattr(ctx, "x_request_id", None)
     if x_request_id:
         headers["x-request-id"] = x_request_id
@@ -56,14 +58,13 @@ class SSHKeygenCredentialsProvider(SSHCredentialsProvider):
             await cls.aiohttp_client.close()
             cls.aiohttp_client = None
 
-    def __init__(self, ssh_keygen_url: str, max_connections: int = 100, *, app_version: str):
+    def __init__(self, ssh_keygen_url: str, max_connections: int = 100):
         self.ssh_keygen_url = ssh_keygen_url
-        self.app_version = app_version
         SSHKeygenCredentialsProvider.max_connections = max_connections
 
     async def get_credentials(self, username: str, jwt_token: str):
         client = await self.get_aiohttp_client()
-        headers = _ssh_service_headers(jwt_token, self.app_version)
+        headers = _ssh_service_headers(jwt_token)
 
         post_data = {
             "duration": "1min",

--- a/src/lib/ssh_clients/ssh_keygen_credentials_provider.py
+++ b/src/lib/ssh_clients/ssh_keygen_credentials_provider.py
@@ -9,27 +9,29 @@ from fastapi import status
 from socket import AF_INET
 from typing import Optional
 
+from starlette_context import context
+from starlette_context.header_keys import HeaderKeys
 
 # exceptions
 from lib.exceptions import SSHServiceError
 from lib.ssh_clients.ssh_credentials_provider import SSHCredentialsProvider
-from lib.request_vars import g
 
 SIZE_POOL_AIOHTTP = 100
 
 
 def _ssh_service_headers(jwt_token: str, app_version: str) -> dict:
-    ctx = g()
     headers = {
         "Content-Type": "application/json",
         "Authorization": f"Bearer {jwt_token}",
-        "x-client-type": getattr(ctx, "x_client_type", None) or "api",
-        "x-client-name": getattr(ctx, "x_client_name", None) or "firecrest",
-        "x-client-version": getattr(ctx, "x_client_version", None) or app_version,
+        "x-client-type": "api",
+        "x-client-name": "firecrest",
+        "x-client-version": app_version,
     }
-    x_request_id = getattr(ctx, "x_request_id", None)
-    if x_request_id:
-        headers["x-request-id"] = x_request_id
+    if context.exists():
+        if HeaderKeys.request_id in context:
+            headers["x-request-id"] = context[HeaderKeys.request_id]
+        if HeaderKeys.correlation_id in context:
+            headers["x-trace-id"] = context[HeaderKeys.correlation_id]
     return headers
 
 

--- a/tests/ssh_keygen_credentials_provider_test.py
+++ b/tests/ssh_keygen_credentials_provider_test.py
@@ -93,6 +93,15 @@ def test_x_request_id_omitted_when_none():
     assert "x-request-id" not in headers
 
 
+def test_empty_string_client_headers_fall_back_to_defaults():
+    _set_context(x_client_type="", x_client_name="", x_client_version="")
+    headers = _ssh_service_headers("token-abc", APP_VERSION)
+
+    assert headers["x-client-type"] == "api"
+    assert headers["x-client-name"] == "firecrest"
+    assert headers["x-client-version"] == APP_VERSION
+
+
 # ---------------------------------------------------------------------------
 # SSHKeygenCredentialsProvider.get_credentials — integration tests
 # ---------------------------------------------------------------------------

--- a/tests/ssh_keygen_credentials_provider_test.py
+++ b/tests/ssh_keygen_credentials_provider_test.py
@@ -3,21 +3,21 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
-import types
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 from fastapi import status
 
-from lib.request_vars import request_global
+from starlette_context import request_cycle_context
+from starlette_context.header_keys import HeaderKeys
+
 from lib.ssh_clients.ssh_keygen_credentials_provider import (
     SSHKeygenCredentialsProvider,
     _ssh_service_headers,
 )
 from lib.exceptions import SSHServiceError
 
-
 SSH_KEYGEN_URL = "http://fake-ssh-service"
-
+APP_VERSION = "2.x.x"
 FAKE_SSH_RESPONSE = {
     "sshKey": {
         "privateKey": "-----BEGIN OPENSSH PRIVATE KEY-----\nfake\n-----END OPENSSH PRIVATE KEY-----",
@@ -26,79 +26,47 @@ FAKE_SSH_RESPONSE = {
 }
 
 
-def _set_context(**kwargs):
-    request_global.set(types.SimpleNamespace(**kwargs))
-
-
-def _clear_context():
-    request_global.set(types.SimpleNamespace())
-
-
 # ---------------------------------------------------------------------------
 # _ssh_service_headers — unit tests
 # ---------------------------------------------------------------------------
 
 
-def test_headers_default_when_no_client_headers():
-    _clear_context()
-    headers = _ssh_service_headers("token-abc")
+def test_headers_default_fields():
+    headers = _ssh_service_headers("token-abc", APP_VERSION)
 
     assert headers["Authorization"] == "Bearer token-abc"
     assert headers["x-client-type"] == "api"
     assert headers["x-client-name"] == "firecrest"
-    assert "x-client-version" not in headers
+    assert headers["x-client-version"] == APP_VERSION
     assert "x-request-id" not in headers
+    assert "x-trace-id" not in headers
 
 
-def test_headers_forwarded_when_client_sends_all():
-    _set_context(
-        x_request_id="req-123",
-        x_client_type="sdk",
-        x_client_name="my-client",
-        x_client_version="1.2.3",
-    )
-    headers = _ssh_service_headers("token-abc")
+def test_headers_include_request_and_trace_id_when_present():
+    with request_cycle_context(
+        {HeaderKeys.request_id: "req-123", HeaderKeys.correlation_id: "corr-456"}
+    ):
+        headers = _ssh_service_headers("token-abc", APP_VERSION)
 
     assert headers["x-request-id"] == "req-123"
-    assert headers["x-client-type"] == "sdk"
-    assert headers["x-client-name"] == "my-client"
-    assert headers["x-client-version"] == "1.2.3"
+    assert headers["x-trace-id"] == "corr-456"
 
 
-def test_headers_partial_forward_falls_back_to_defaults():
-    _set_context(
-        x_client_type="sdk",
-        # x_client_name and x_client_version not set by client
-    )
-    headers = _ssh_service_headers("token-abc")
-
-    assert headers["x-client-type"] == "sdk"
-    assert headers["x-client-name"] == "firecrest"
-    assert "x-client-version" not in headers
-    assert "x-request-id" not in headers
-
-
-def test_x_request_id_omitted_when_absent():
-    _set_context(x_client_type="api")
-    headers = _ssh_service_headers("token-abc")
+def test_headers_omit_request_and_trace_id_when_absent_from_context():
+    with request_cycle_context({}):
+        headers = _ssh_service_headers("token-abc", APP_VERSION)
 
     assert "x-request-id" not in headers
+    assert "x-trace-id" not in headers
 
 
-def test_x_request_id_omitted_when_none():
-    _set_context(x_request_id=None)
-    headers = _ssh_service_headers("token-abc")
+def test_headers_safe_outside_request_response_cycle():
+    # No starlette_context set up at all, e.g. when called from a background
+    # scheduler task (health checks) rather than an HTTP request.
+    headers = _ssh_service_headers("token-abc", APP_VERSION)
 
     assert "x-request-id" not in headers
-
-
-def test_empty_string_client_headers_fall_back_to_defaults():
-    _set_context(x_client_type="", x_client_name="", x_client_version="")
-    headers = _ssh_service_headers("token-abc")
-
-    assert headers["x-client-type"] == "api"
-    assert headers["x-client-name"] == "firecrest"
-    assert "x-client-version" not in headers
+    assert "x-trace-id" not in headers
 
 
 # ---------------------------------------------------------------------------
@@ -106,7 +74,9 @@ def test_empty_string_client_headers_fall_back_to_defaults():
 # ---------------------------------------------------------------------------
 
 
-def _make_mock_session(response_status: int, response_payload: dict = None, response_body: str = ""):
+def _make_mock_session(
+    response_status: int, response_payload: dict = None, response_body: str = ""
+):
     mock_response = MagicMock()
     mock_response.status = response_status
     mock_response.json = AsyncMock(return_value=response_payload)
@@ -126,11 +96,14 @@ def _sent_headers(mock_session) -> dict:
 
 
 async def test_get_credentials_returns_ssh_keys():
-    _clear_context()
-    provider = SSHKeygenCredentialsProvider(SSH_KEYGEN_URL)
+    provider = SSHKeygenCredentialsProvider(SSH_KEYGEN_URL, app_version=APP_VERSION)
     mock_session = _make_mock_session(status.HTTP_201_CREATED, FAKE_SSH_RESPONSE)
 
-    with patch.object(SSHKeygenCredentialsProvider, "get_aiohttp_client", AsyncMock(return_value=mock_session)):
+    with patch.object(
+        SSHKeygenCredentialsProvider,
+        "get_aiohttp_client",
+        AsyncMock(return_value=mock_session),
+    ):
         credentials = await provider.get_credentials("fireuser", "token-abc")
 
     assert credentials.private_key.startswith("-----BEGIN OPENSSH PRIVATE KEY-----")
@@ -138,45 +111,53 @@ async def test_get_credentials_returns_ssh_keys():
 
 
 async def test_get_credentials_sends_default_monitoring_headers():
-    _clear_context()
-    provider = SSHKeygenCredentialsProvider(SSH_KEYGEN_URL)
+    provider = SSHKeygenCredentialsProvider(SSH_KEYGEN_URL, app_version=APP_VERSION)
     mock_session = _make_mock_session(status.HTTP_201_CREATED, FAKE_SSH_RESPONSE)
 
-    with patch.object(SSHKeygenCredentialsProvider, "get_aiohttp_client", AsyncMock(return_value=mock_session)):
+    with patch.object(
+        SSHKeygenCredentialsProvider,
+        "get_aiohttp_client",
+        AsyncMock(return_value=mock_session),
+    ):
         await provider.get_credentials("fireuser", "token-abc")
 
     sent = _sent_headers(mock_session)
     assert sent["x-client-type"] == "api"
     assert sent["x-client-name"] == "firecrest"
-    assert "x-client-version" not in sent
+    assert sent["x-client-version"] == APP_VERSION
     assert "x-request-id" not in sent
+    assert "x-trace-id" not in sent
 
 
-async def test_get_credentials_forwards_client_headers():
-    _set_context(
-        x_request_id="req-456",
-        x_client_type="sdk",
-        x_client_name="my-app",
-        x_client_version="3.0.0",
-    )
-    provider = SSHKeygenCredentialsProvider(SSH_KEYGEN_URL)
+async def test_get_credentials_forwards_request_and_trace_id():
+    provider = SSHKeygenCredentialsProvider(SSH_KEYGEN_URL, app_version=APP_VERSION)
     mock_session = _make_mock_session(status.HTTP_201_CREATED, FAKE_SSH_RESPONSE)
 
-    with patch.object(SSHKeygenCredentialsProvider, "get_aiohttp_client", AsyncMock(return_value=mock_session)):
-        await provider.get_credentials("fireuser", "token-abc")
+    with patch.object(
+        SSHKeygenCredentialsProvider,
+        "get_aiohttp_client",
+        AsyncMock(return_value=mock_session),
+    ):
+        with request_cycle_context(
+            {HeaderKeys.request_id: "req-456", HeaderKeys.correlation_id: "corr-789"}
+        ):
+            await provider.get_credentials("fireuser", "token-abc")
 
     sent = _sent_headers(mock_session)
     assert sent["x-request-id"] == "req-456"
-    assert sent["x-client-type"] == "sdk"
-    assert sent["x-client-name"] == "my-app"
-    assert sent["x-client-version"] == "3.0.0"
+    assert sent["x-trace-id"] == "corr-789"
 
 
 async def test_get_credentials_raises_on_non_201():
-    _clear_context()
-    provider = SSHKeygenCredentialsProvider(SSH_KEYGEN_URL)
-    mock_session = _make_mock_session(status.HTTP_500_INTERNAL_SERVER_ERROR, response_body="Internal error")
+    provider = SSHKeygenCredentialsProvider(SSH_KEYGEN_URL, app_version=APP_VERSION)
+    mock_session = _make_mock_session(
+        status.HTTP_500_INTERNAL_SERVER_ERROR, response_body="Internal error"
+    )
 
-    with patch.object(SSHKeygenCredentialsProvider, "get_aiohttp_client", AsyncMock(return_value=mock_session)):
+    with patch.object(
+        SSHKeygenCredentialsProvider,
+        "get_aiohttp_client",
+        AsyncMock(return_value=mock_session),
+    ):
         with pytest.raises(SSHServiceError):
             await provider.get_credentials("fireuser", "token-abc")

--- a/tests/ssh_keygen_credentials_provider_test.py
+++ b/tests/ssh_keygen_credentials_provider_test.py
@@ -17,7 +17,6 @@ from lib.exceptions import SSHServiceError
 
 
 SSH_KEYGEN_URL = "http://fake-ssh-service"
-APP_VERSION = "2.x.x"
 
 FAKE_SSH_RESPONSE = {
     "sshKey": {
@@ -42,12 +41,12 @@ def _clear_context():
 
 def test_headers_default_when_no_client_headers():
     _clear_context()
-    headers = _ssh_service_headers("token-abc", APP_VERSION)
+    headers = _ssh_service_headers("token-abc")
 
     assert headers["Authorization"] == "Bearer token-abc"
     assert headers["x-client-type"] == "api"
     assert headers["x-client-name"] == "firecrest"
-    assert headers["x-client-version"] == APP_VERSION
+    assert "x-client-version" not in headers
     assert "x-request-id" not in headers
 
 
@@ -58,7 +57,7 @@ def test_headers_forwarded_when_client_sends_all():
         x_client_name="my-client",
         x_client_version="1.2.3",
     )
-    headers = _ssh_service_headers("token-abc", APP_VERSION)
+    headers = _ssh_service_headers("token-abc")
 
     assert headers["x-request-id"] == "req-123"
     assert headers["x-client-type"] == "sdk"
@@ -71,35 +70,35 @@ def test_headers_partial_forward_falls_back_to_defaults():
         x_client_type="sdk",
         # x_client_name and x_client_version not set by client
     )
-    headers = _ssh_service_headers("token-abc", APP_VERSION)
+    headers = _ssh_service_headers("token-abc")
 
     assert headers["x-client-type"] == "sdk"
     assert headers["x-client-name"] == "firecrest"
-    assert headers["x-client-version"] == APP_VERSION
+    assert "x-client-version" not in headers
     assert "x-request-id" not in headers
 
 
 def test_x_request_id_omitted_when_absent():
     _set_context(x_client_type="api")
-    headers = _ssh_service_headers("token-abc", APP_VERSION)
+    headers = _ssh_service_headers("token-abc")
 
     assert "x-request-id" not in headers
 
 
 def test_x_request_id_omitted_when_none():
     _set_context(x_request_id=None)
-    headers = _ssh_service_headers("token-abc", APP_VERSION)
+    headers = _ssh_service_headers("token-abc")
 
     assert "x-request-id" not in headers
 
 
 def test_empty_string_client_headers_fall_back_to_defaults():
     _set_context(x_client_type="", x_client_name="", x_client_version="")
-    headers = _ssh_service_headers("token-abc", APP_VERSION)
+    headers = _ssh_service_headers("token-abc")
 
     assert headers["x-client-type"] == "api"
     assert headers["x-client-name"] == "firecrest"
-    assert headers["x-client-version"] == APP_VERSION
+    assert "x-client-version" not in headers
 
 
 # ---------------------------------------------------------------------------
@@ -128,7 +127,7 @@ def _sent_headers(mock_session) -> dict:
 
 async def test_get_credentials_returns_ssh_keys():
     _clear_context()
-    provider = SSHKeygenCredentialsProvider(SSH_KEYGEN_URL, app_version=APP_VERSION)
+    provider = SSHKeygenCredentialsProvider(SSH_KEYGEN_URL)
     mock_session = _make_mock_session(status.HTTP_201_CREATED, FAKE_SSH_RESPONSE)
 
     with patch.object(SSHKeygenCredentialsProvider, "get_aiohttp_client", AsyncMock(return_value=mock_session)):
@@ -140,7 +139,7 @@ async def test_get_credentials_returns_ssh_keys():
 
 async def test_get_credentials_sends_default_monitoring_headers():
     _clear_context()
-    provider = SSHKeygenCredentialsProvider(SSH_KEYGEN_URL, app_version=APP_VERSION)
+    provider = SSHKeygenCredentialsProvider(SSH_KEYGEN_URL)
     mock_session = _make_mock_session(status.HTTP_201_CREATED, FAKE_SSH_RESPONSE)
 
     with patch.object(SSHKeygenCredentialsProvider, "get_aiohttp_client", AsyncMock(return_value=mock_session)):
@@ -149,7 +148,7 @@ async def test_get_credentials_sends_default_monitoring_headers():
     sent = _sent_headers(mock_session)
     assert sent["x-client-type"] == "api"
     assert sent["x-client-name"] == "firecrest"
-    assert sent["x-client-version"] == APP_VERSION
+    assert "x-client-version" not in sent
     assert "x-request-id" not in sent
 
 
@@ -160,7 +159,7 @@ async def test_get_credentials_forwards_client_headers():
         x_client_name="my-app",
         x_client_version="3.0.0",
     )
-    provider = SSHKeygenCredentialsProvider(SSH_KEYGEN_URL, app_version=APP_VERSION)
+    provider = SSHKeygenCredentialsProvider(SSH_KEYGEN_URL)
     mock_session = _make_mock_session(status.HTTP_201_CREATED, FAKE_SSH_RESPONSE)
 
     with patch.object(SSHKeygenCredentialsProvider, "get_aiohttp_client", AsyncMock(return_value=mock_session)):
@@ -175,7 +174,7 @@ async def test_get_credentials_forwards_client_headers():
 
 async def test_get_credentials_raises_on_non_201():
     _clear_context()
-    provider = SSHKeygenCredentialsProvider(SSH_KEYGEN_URL, app_version=APP_VERSION)
+    provider = SSHKeygenCredentialsProvider(SSH_KEYGEN_URL)
     mock_session = _make_mock_session(status.HTTP_500_INTERNAL_SERVER_ERROR, response_body="Internal error")
 
     with patch.object(SSHKeygenCredentialsProvider, "get_aiohttp_client", AsyncMock(return_value=mock_session)):

--- a/tests/ssh_keygen_credentials_provider_test.py
+++ b/tests/ssh_keygen_credentials_provider_test.py
@@ -1,0 +1,174 @@
+# Copyright (c) 2025, ETH Zurich. All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import types
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from fastapi import status
+
+from lib.request_vars import request_global
+from lib.ssh_clients.ssh_keygen_credentials_provider import (
+    SSHKeygenCredentialsProvider,
+    _ssh_service_headers,
+)
+from lib.exceptions import SSHServiceError
+
+
+SSH_KEYGEN_URL = "http://fake-ssh-service"
+APP_VERSION = "2.x.x"
+
+FAKE_SSH_RESPONSE = {
+    "sshKey": {
+        "privateKey": "-----BEGIN OPENSSH PRIVATE KEY-----\nfake\n-----END OPENSSH PRIVATE KEY-----",
+        "publicKey": "ssh-rsa AAAAB3NzaC1yc2E fake",
+    }
+}
+
+
+def _set_context(**kwargs):
+    request_global.set(types.SimpleNamespace(**kwargs))
+
+
+def _clear_context():
+    request_global.set(types.SimpleNamespace())
+
+
+# ---------------------------------------------------------------------------
+# _ssh_service_headers — unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_headers_default_when_no_client_headers():
+    _clear_context()
+    headers = _ssh_service_headers("token-abc", APP_VERSION)
+
+    assert headers["Authorization"] == "Bearer token-abc"
+    assert headers["x-client-type"] == "api"
+    assert headers["x-client-name"] == "firecrest"
+    assert headers["x-client-version"] == APP_VERSION
+    assert "x-request-id" not in headers
+
+
+def test_headers_forwarded_when_client_sends_all():
+    _set_context(
+        x_request_id="req-123",
+        x_client_type="sdk",
+        x_client_name="my-client",
+        x_client_version="1.2.3",
+    )
+    headers = _ssh_service_headers("token-abc", APP_VERSION)
+
+    assert headers["x-request-id"] == "req-123"
+    assert headers["x-client-type"] == "sdk"
+    assert headers["x-client-name"] == "my-client"
+    assert headers["x-client-version"] == "1.2.3"
+
+
+def test_headers_partial_forward_falls_back_to_defaults():
+    _set_context(
+        x_client_type="sdk",
+        # x_client_name and x_client_version not set by client
+    )
+    headers = _ssh_service_headers("token-abc", APP_VERSION)
+
+    assert headers["x-client-type"] == "sdk"
+    assert headers["x-client-name"] == "firecrest"
+    assert headers["x-client-version"] == APP_VERSION
+    assert "x-request-id" not in headers
+
+
+def test_x_request_id_omitted_when_absent():
+    _set_context(x_client_type="api")
+    headers = _ssh_service_headers("token-abc", APP_VERSION)
+
+    assert "x-request-id" not in headers
+
+
+def test_x_request_id_omitted_when_none():
+    _set_context(x_request_id=None)
+    headers = _ssh_service_headers("token-abc", APP_VERSION)
+
+    assert "x-request-id" not in headers
+
+
+# ---------------------------------------------------------------------------
+# SSHKeygenCredentialsProvider.get_credentials — integration tests
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_session(response_status: int, response_payload: dict = None, response_body: str = ""):
+    mock_response = MagicMock()
+    mock_response.status = response_status
+    mock_response.json = AsyncMock(return_value=response_payload)
+    mock_response.text = AsyncMock(return_value=response_body)
+
+    mock_context = MagicMock()
+    mock_context.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_context.__aexit__ = AsyncMock(return_value=None)
+
+    mock_session = MagicMock()
+    mock_session.post = MagicMock(return_value=mock_context)
+    return mock_session
+
+
+def _sent_headers(mock_session) -> dict:
+    return mock_session.post.call_args.kwargs["headers"]
+
+
+async def test_get_credentials_returns_ssh_keys():
+    _clear_context()
+    provider = SSHKeygenCredentialsProvider(SSH_KEYGEN_URL, app_version=APP_VERSION)
+    mock_session = _make_mock_session(status.HTTP_201_CREATED, FAKE_SSH_RESPONSE)
+
+    with patch.object(SSHKeygenCredentialsProvider, "get_aiohttp_client", AsyncMock(return_value=mock_session)):
+        credentials = await provider.get_credentials("fireuser", "token-abc")
+
+    assert credentials.private_key.startswith("-----BEGIN OPENSSH PRIVATE KEY-----")
+    assert credentials.public_certificate.startswith("ssh-rsa")
+
+
+async def test_get_credentials_sends_default_monitoring_headers():
+    _clear_context()
+    provider = SSHKeygenCredentialsProvider(SSH_KEYGEN_URL, app_version=APP_VERSION)
+    mock_session = _make_mock_session(status.HTTP_201_CREATED, FAKE_SSH_RESPONSE)
+
+    with patch.object(SSHKeygenCredentialsProvider, "get_aiohttp_client", AsyncMock(return_value=mock_session)):
+        await provider.get_credentials("fireuser", "token-abc")
+
+    sent = _sent_headers(mock_session)
+    assert sent["x-client-type"] == "api"
+    assert sent["x-client-name"] == "firecrest"
+    assert sent["x-client-version"] == APP_VERSION
+    assert "x-request-id" not in sent
+
+
+async def test_get_credentials_forwards_client_headers():
+    _set_context(
+        x_request_id="req-456",
+        x_client_type="sdk",
+        x_client_name="my-app",
+        x_client_version="3.0.0",
+    )
+    provider = SSHKeygenCredentialsProvider(SSH_KEYGEN_URL, app_version=APP_VERSION)
+    mock_session = _make_mock_session(status.HTTP_201_CREATED, FAKE_SSH_RESPONSE)
+
+    with patch.object(SSHKeygenCredentialsProvider, "get_aiohttp_client", AsyncMock(return_value=mock_session)):
+        await provider.get_credentials("fireuser", "token-abc")
+
+    sent = _sent_headers(mock_session)
+    assert sent["x-request-id"] == "req-456"
+    assert sent["x-client-type"] == "sdk"
+    assert sent["x-client-name"] == "my-app"
+    assert sent["x-client-version"] == "3.0.0"
+
+
+async def test_get_credentials_raises_on_non_201():
+    _clear_context()
+    provider = SSHKeygenCredentialsProvider(SSH_KEYGEN_URL, app_version=APP_VERSION)
+    mock_session = _make_mock_session(status.HTTP_500_INTERNAL_SERVER_ERROR, response_body="Internal error")
+
+    with patch.object(SSHKeygenCredentialsProvider, "get_aiohttp_client", AsyncMock(return_value=mock_session)):
+        with pytest.raises(SSHServiceError):
+            await provider.get_credentials("fireuser", "token-abc")


### PR DESCRIPTION
## Summary
Captures `x-request-id`, `x-client-type`, `x-client-name`, and `x-client-version` from incoming requests in `init_request_vars`.

`SSHKeygenCredentialsProvider` reads from that context when building the outgoing headers to the hpc-ssh key generation service:
- Client values are forwarded as-is.
- Missing `x-client-type` / `x-client-name` fall back to firecrest defaults (`api` / `firecrest`).
- `x-client-version` and `x-request-id` are omitted entirely if the original request did not include them — no `app_version` fallback, since that's redundant with firecrest's own logging.

## Testing
- Verified locally via docker-compose: called `GET /filesystem/{system}/ops/ls` against a live firecrest instance with a custom `x-request-id`, and confirmed the same ID appears in hpc-ssh's structured logs, threaded through the entire key generation flow (generate → sign cert → cleanup).
- SSH key generation succeeds end-to-end (`POST /api/v1/ssh-keys` → 201 Created).
- Unit tests in `ssh_keygen_credentials_provider_test.py` cover header forwarding, partial fallback, empty-string fallback, and omission of `x-client-version`/`x-request-id` when absent — all passing.