### PR TITLE
Skip status check allows command execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.5.4] - OPEN
+## [2.5.5] - OPEN
+
+### Added
+
+### Changed
+
+### Fixed
+
+- Execute commands when the health check is disabled
+
+## [2.5.4]
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- SSH connection pool locking is now per-user instead of global, reducing unnecessary SSH connection wait times. The max_clients connection pool setting is no longer a hard limit; under a high number of concurrent requests, the limit may be temporarily exceeded.
+
 ### Fixed
 
-- SSH connection pool locking is now per-user instead of global, reducing unnecessary SSH connection wait times. The max_clients connection pool setting is no longer a hard limit; under a high number of concurrent requests, the limit may be temporarily exceeded.
 - Allow command execution when the health check is disabled
 
 ## [2.5.5]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,20 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.5.5] - OPEN
+## [2.5.6] - OPEN
 
+### Added
+
+### Changed
+
+### Fixed
+
+- Allow command execution when the health check is disabled
+
+## [2.5.5]
 
 ### Added
 
 - Trace logs now include both request and response trace.
-
 
 ### Fixed
 
 - Fixes truncation of `workingDirectory` in job responses for running/pending jobs caused by `squeue`'s default 20-character column width.
 - Fixes error handling of downstream services.
 - Fixes log tracing
-- Execute commands when the health check is disabled
+
 
 
 ## [2.5.4]

--- a/f7t-api-config.local-env-tests.yaml
+++ b/f7t-api-config.local-env-tests.yaml
@@ -103,6 +103,50 @@ clusters:
         max_part_size: 1073741824 # 1G
         parallel_runs: 3
         tmp_folder: "tmp"
+- name: "cluster-SLURM-ssh-no-health-check"
+  ssh:
+    host: "192.168.240.2"
+    port: 22
+    max_clients: 500
+  scheduler:
+    type: "slurm"
+    version: "24.11.0"
+    timeout: 10
+  service_account:
+    client_id: "firecrest-api"
+    secret: ""
+  probing:
+    interval_check: 60
+    services:      
+      storage:
+        timeout: 10
+  file_systems:
+    - path: '/wrong_path'
+      data_type: 'scratch'
+      default_work_dir: false
+    - path: '/home'
+      data_type: 'users'
+      default_work_dir: true
+  data_operation:
+    max_ops_file_size: 5242880 # 5M
+    datatransfer_jobs_directives:
+      - "#SBATCH --nodes=1"
+      - "#SBATCH --time=0-00:15:00"
+      - "#SBATCH --account={account}"
+    data_transfer:
+      name: "s3-storage"
+      service_type: "s3"
+      private_url: "http://192.168.240.19:9000"
+      public_url: "http://localhost:9000"
+      access_key_id: "storage_access_key"
+      secret_access_key: ""
+      region: "us-east-1"
+      ttl: 604800
+      multipart:
+        use_split: false
+        max_part_size: 1073741824 # 1G
+        parallel_runs: 3
+        tmp_folder: "tmp"
 - name: "cluster-pbs"
   ssh:
     host: "192.168.240.2"

--- a/f7t-api-config.local-env-tests.yaml
+++ b/f7t-api-config.local-env-tests.yaml
@@ -83,6 +83,9 @@ clusters:
     - path: '/home'
       data_type: 'users'
       default_work_dir: true
+    - path: '/scratch'
+      data_type: 'scratch'
+      default_work_dir: false
   data_operation:
     max_ops_file_size: 5242880 # 5M
     datatransfer_jobs_directives:
@@ -121,12 +124,12 @@ clusters:
       storage:
         timeout: 10
   file_systems:
-    - path: '/wrong_path'
-      data_type: 'scratch'
-      default_work_dir: false
     - path: '/home'
       data_type: 'users'
       default_work_dir: true
+    - path: '/scratch'
+      data_type: 'scratch'
+      default_work_dir: false
   data_operation:
     max_ops_file_size: 5242880 # 5M
     datatransfer_jobs_directives:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Authlib
 pydantic
 pydantic-settings >= 2.2.0
 setuptools
-aiohttp
+aiohttp < 3.14 # Temporary fix to avoid aioresponses compatibility issues with aiohttp 3.14 (https://github.com/pnuckowski/aioresponses/pull/288)
 asyncio
 rootpath
 asyncssh

--- a/src/firecrest/config.py
+++ b/src/firecrest/config.py
@@ -378,6 +378,12 @@ class DataOperation(BaseModel):
 class FileSystem(CamelModel):
     """Defines a cluster file system and its type."""
 
+    @pydantic.field_validator("path", mode="before")
+    def normalize_path(cls, value):
+        if isinstance(value, str):
+            return os.path.normpath(value)
+        return value
+
     path: str = Field(..., description="Mount path for the file system.")
     data_type: FileSystemDataType = Field(..., description="File system purpose/type.")
     default_work_dir: bool = Field(

--- a/src/firecrest/dependencies.py
+++ b/src/firecrest/dependencies.py
@@ -118,6 +118,18 @@ class ServiceAvailabilityDependency:
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="All filesystem requests require a path or source_path parameter.",
             )
+
+        valid_path = None
+        valid_path = next(
+            (fs.path for fs in system.file_systems if path.startswith(fs.path)),
+            None
+        )
+        if valid_path is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"The provided path ({path}) does not match any of the defined filesystem paths for the requested system ({system.name}).",
+            )
+
         service = None
         if system.servicesHealth:
             service = next(
@@ -128,12 +140,7 @@ class ServiceAvailabilityDependency:
                 ),
                 None,
             )
-        if service is None:
-            raise HTTPException(
-                status_code=status.HTTP_428_PRECONDITION_REQUIRED,
-                detail=f"No filesystem health checker serving the request path was found on {system.name}.",
-            )
-        if not service.healthy:
+        if service and not service.healthy:
             raise HTTPException(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                 detail=f"The requested filesystem ({service.path} on {system.name}) is unhealthy.",
@@ -149,12 +156,7 @@ class ServiceAvailabilityDependency:
                 ),
                 None,
             )
-        if service is None:
-            raise HTTPException(
-                status_code=status.HTTP_428_PRECONDITION_REQUIRED,
-                detail=f"No scheduler health checker for the requested system ({system.name}) was found.",
-            )
-        if not service.healthy:
+        if service and not service.healthy:
             raise HTTPException(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                 detail=f"The scheduler service for the requested system ({system.name}) is unhealthy.",
@@ -170,12 +172,7 @@ class ServiceAvailabilityDependency:
                 ),
                 None,
             )
-        if service is None:
-            raise HTTPException(
-                status_code=status.HTTP_428_PRECONDITION_REQUIRED,
-                detail=f"No ssh health checker for the requested system ({system.name}) was found.",
-            )
-        if not service.healthy:
+        if service and not service.healthy:
             raise HTTPException(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                 detail=f"The ssh service for the requested system ({system.name}) is unhealthy.",

--- a/src/firecrest/dependencies.py
+++ b/src/firecrest/dependencies.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import asyncio
+import os
 from fastapi import Request, status, HTTPException
 from aiobotocore.config import AioConfig
 from aiobotocore.session import get_session
@@ -119,9 +120,9 @@ class ServiceAvailabilityDependency:
                 detail="All filesystem requests require a path or source_path parameter.",
             )
 
-        valid_path = None
+        norm_path = os.path.normpath(path)
         valid_path = next(
-            (fs.path for fs in system.file_systems if path.startswith(fs.path)),
+            (fs.path for fs in system.file_systems if norm_path == fs.path or norm_path.startswith(fs.path.rstrip("/")+"/")),
             None
         )
         if valid_path is None:

--- a/src/firecrest/dependencies.py
+++ b/src/firecrest/dependencies.py
@@ -126,8 +126,7 @@ class ServiceAvailabilityDependency:
                 detail=f"The provided path ({path}) is not an absolute path.",
             )
 
-        norm_path = os.path.normpath(path)
-        print(system.file_systems)
+        norm_path = os.path.normpath(path)        
         valid_path = next(
             (fs.path for fs in system.file_systems if norm_path == fs.path or norm_path.startswith(fs.path.rstrip("/")+"/")),
             None

--- a/src/firecrest/dependencies.py
+++ b/src/firecrest/dependencies.py
@@ -120,6 +120,12 @@ class ServiceAvailabilityDependency:
                 detail="All filesystem requests require a path or source_path parameter.",
             )
 
+        if not os.path.isabs(path):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"The provided path ({path}) is not an absolute path.",
+            )
+
         norm_path = os.path.normpath(path)
         valid_path = next(
             (fs.path for fs in system.file_systems if norm_path == fs.path or norm_path.startswith(fs.path.rstrip("/")+"/")),
@@ -128,7 +134,7 @@ class ServiceAvailabilityDependency:
         if valid_path is None:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"The provided path ({path}) does not match any of the defined filesystem paths for the requested system ({system.name}).",
+                detail=f"The provided path ({norm_path}) does not match any of the defined filesystem paths for the requested system ({system.name}).",
             )
 
         service = None
@@ -136,7 +142,7 @@ class ServiceAvailabilityDependency:
             service = next(
                 filter(
                     lambda service: service.service_type == self.service_type
-                    and path.startswith(service.path),
+                    and (norm_path == service.path or norm_path.startswith(service.path.rstrip("/")+"/")),
                     system.servicesHealth,
                 ),
                 None,

--- a/src/firecrest/dependencies.py
+++ b/src/firecrest/dependencies.py
@@ -127,8 +127,9 @@ class ServiceAvailabilityDependency:
             )
 
         norm_path = os.path.normpath(path)
+        print(system.file_systems)
         valid_path = next(
-            (fs.path for fs in system.file_systems if norm_path == fs.path or norm_path.startswith(fs.path.rstrip("/"))),
+            (fs.path for fs in system.file_systems if norm_path == fs.path or norm_path.startswith(fs.path.rstrip("/")+"/")),
             None
         )
         if valid_path is None:
@@ -142,7 +143,7 @@ class ServiceAvailabilityDependency:
             service = next(
                 filter(
                     lambda service: service.service_type == self.service_type
-                    and (norm_path == service.path or norm_path.startswith(service.path.rstrip("/"))),
+                    and (norm_path == service.path or norm_path.startswith(service.path.rstrip("/")+"/")),
                     system.servicesHealth,
                 ),
                 None,

--- a/src/firecrest/dependencies.py
+++ b/src/firecrest/dependencies.py
@@ -128,7 +128,7 @@ class ServiceAvailabilityDependency:
 
         norm_path = os.path.normpath(path)
         valid_path = next(
-            (fs.path for fs in system.file_systems if norm_path == fs.path or norm_path.startswith(fs.path.rstrip("/")+"/")),
+            (fs.path for fs in system.file_systems if norm_path == fs.path or norm_path.startswith(fs.path.rstrip("/"))),
             None
         )
         if valid_path is None:
@@ -142,7 +142,7 @@ class ServiceAvailabilityDependency:
             service = next(
                 filter(
                     lambda service: service.service_type == self.service_type
-                    and (norm_path == service.path or norm_path.startswith(service.path.rstrip("/")+"/")),
+                    and (norm_path == service.path or norm_path.startswith(service.path.rstrip("/"))),
                     system.servicesHealth,
                 ),
                 None,

--- a/tests/clusters_config_test.py
+++ b/tests/clusters_config_test.py
@@ -22,7 +22,7 @@ def app_settings():
 async def test_settings(app_settings: Settings):
 
     assert app_settings is not None
-    assert len(app_settings.clusters) == 3
+    assert len(app_settings.clusters) == 4
     assert (
         # test case insensitive, name is always lower case
         app_settings.clusters[0].name

--- a/tests/compute_slurm_ssh_test.py
+++ b/tests/compute_slurm_ssh_test.py
@@ -9,6 +9,7 @@ from tests import mocked_ssh_outputs
 import json
 
 from tests.mock_ssh_client import MockedCommand
+from tests.helpers import helper_test_get_job, mocked_ssh_sacct_output
 
 
 @pytest.fixture(scope="module")
@@ -25,21 +26,6 @@ def mocked_ssh_sbatch_output_out_of_quota():
     )
     with output_file.open("rb") as output:
         return json.load(output)
-
-
-@pytest.fixture(scope="module")
-def mocked_ssh_sacct_output():
-    output_file = impresources.files(mocked_ssh_outputs) / "ssh_sacct_command.json"
-    with output_file.open("rb") as output:
-        return json.load(output)
-
-
-@pytest.fixture(scope="module")
-def mocked_ssh_squeue_output():
-    output_file = impresources.files(mocked_ssh_outputs) / "ssh_squeue_command.json"
-    with output_file.open("rb") as output:
-        return json.load(output)
-
 
 @pytest.fixture(scope="module")
 def mocked_ssh_squeue_allusers_output():
@@ -159,27 +145,15 @@ async def test_submit_job_out_of_quota(
 
 async def test_get_job(
     client,
-    ssh_client,
-    mocked_ssh_sacct_output,
-    mocked_ssh_squeue_output,
+    ssh_client,    
     slurm_cluster_with_ssh_config,
 ):
 
-    async with ssh_client.mocked_output(
-        [
-            MockedCommand(**mocked_ssh_sacct_output),
-            MockedCommand(**mocked_ssh_squeue_output),
-        ]
-    ):
-        response = client.get(
-            "/compute/{cluster_name}/jobs/{job_id}".format(
-                cluster_name=slurm_cluster_with_ssh_config.name, job_id=1
-            )
-        )
-        assert response.status_code == 200
-        assert response.json() is not None
-
-        assert response.json()["jobs"][0]["status"]["exitCode"] == 0
+    await helper_test_get_job(
+        client,
+        ssh_client,
+        cluster_name=slurm_cluster_with_ssh_config.name
+    )
 
 
 async def test_get_jobs_allusers(
@@ -209,8 +183,7 @@ async def test_get_jobs_allusers(
 
 async def test_get_job_metadata(
     client,
-    ssh_client,
-    mocked_ssh_sacct_output,
+    ssh_client,    
     mocked_ssh_sacct_script_output,
     mocked_ssh_scontrol_script_output,
     mocked_ssh_scontrol_job_output,
@@ -219,7 +192,7 @@ async def test_get_job_metadata(
 
     async with ssh_client.mocked_output(
         [
-            MockedCommand(**mocked_ssh_sacct_output),
+            MockedCommand(**mocked_ssh_sacct_output()),
             MockedCommand(**mocked_ssh_sacct_script_output),
             MockedCommand(**mocked_ssh_scontrol_script_output),
             MockedCommand(**mocked_ssh_scontrol_job_output),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -216,6 +216,13 @@ def set_up_cluster_health():
                     "latency": 0,
                     "healthy": True,
                     "path": "/home",
-                },                
+                },
+                {
+                    "serviceType": "filesystem",
+                    "lastChecked": datetime.now(),
+                    "latency": 0,
+                    "healthy": False,
+                    "path": "/scratch",
+                },
             ]
         cluster.servicesHealth = health

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -194,25 +194,28 @@ def client(app, s3_client, ssh_client):
 def set_up_cluster_health():
     settings = get_settings()
     for cluster in settings.clusters:
-        health = [
-            {
-                "serviceType": "scheduler",
-                "lastChecked": datetime.now(),
-                "latency": 0,
-                "healthy": True,
-            },
-            {
-                "serviceType": "ssh",
-                "lastChecked": datetime.now(),
-                "latency": 0,
-                "healthy": True,
-            },
-            {
-                "serviceType": "filesystem",
-                "lastChecked": datetime.now(),
-                "latency": 0,
-                "healthy": True,
-                "path": "/home",
-            },
-        ]
+        if cluster.name.lower() == "cluster-slurm-ssh-no-health-check":
+            health = None
+        else:
+            health = [
+                {
+                    "serviceType": "scheduler",
+                    "lastChecked": datetime.now(),
+                    "latency": 0,
+                    "healthy": True,
+                },
+                {
+                    "serviceType": "ssh",
+                    "lastChecked": datetime.now(),
+                    "latency": 0,
+                    "healthy": True,
+                },
+                {
+                    "serviceType": "filesystem",
+                    "lastChecked": datetime.now(),
+                    "latency": 0,
+                    "healthy": True,
+                    "path": "/home",
+                },                
+            ]
         cluster.servicesHealth = health

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -143,6 +143,15 @@ def slurm_cluster_with_ssh_config():
 
 
 @pytest.fixture(scope="module")
+def slurm_cluster_with_ssh_no_health_check_config():
+    for cluster in settings.clusters:
+        if (
+            getattr(cluster, "name", None).lower() == "cluster-slurm-ssh-no-health-check"
+        ):
+            return cluster
+
+
+@pytest.fixture(scope="module")
 def pbs_cluster():
     for cluster in settings.clusters:
         if getattr(cluster.scheduler, "type", "").lower() == "pbs":

--- a/tests/filesystem_ops_test.py
+++ b/tests/filesystem_ops_test.py
@@ -10,18 +10,20 @@ from tests import mocked_ssh_outputs
 import pytest
 import json
 
+from tests.helpers import load_ssh_output, helper_test_ls_command
+
 from tests.mock_ssh_client import MockedCommand
 
 
-def load_ssh_output(file: str):
-    output_file = impresources.files(mocked_ssh_outputs) / file
-    with output_file.open("rb") as output:
-        return json.load(output, strict=False)
+# def load_ssh_output(file: str):
+#     output_file = impresources.files(mocked_ssh_outputs) / file
+#     with output_file.open("rb") as output:
+#         return json.load(output, strict=False)
 
 
-@pytest.fixture(scope="module")
-def mocked_ssh_ls_output():
-    return load_ssh_output("ssh_ls_command.json")
+# @pytest.fixture(scope="module")
+# def mocked_ssh_ls_output():
+#     return load_ssh_output("ssh_ls_command.json")
 
 
 @pytest.fixture(scope="module")
@@ -130,19 +132,10 @@ def mocked_ssh_tar_output():
 
 
 async def test_ls_command(client,
-                          ssh_client, mocked_ssh_ls_output,
+                          ssh_client,
                           cluster_name="cluster-slurm-ssh"):
 
-    async with ssh_client.mocked_output([MockedCommand(**mocked_ssh_ls_output)]):
-
-        response = client.get(
-            "/filesystem/{cluster_name}/ops/ls?path={path}".format(
-                cluster_name=cluster_name, path="/home"
-            )
-        )
-        assert response.status_code == 200
-        assert response.json() is not None
-        assert len(response.json()["output"]) == 4
+    await helper_test_ls_command(client, ssh_client)
 
 
 async def test_ls_recursive_command(client, ssh_client, mocked_ssh_ls_recursive_output):

--- a/tests/filesystem_ops_test.py
+++ b/tests/filesystem_ops_test.py
@@ -129,12 +129,16 @@ def mocked_ssh_tar_output():
     return load_ssh_output("ssh_tar_command.json")
 
 
-async def test_ls_command(client, ssh_client, mocked_ssh_ls_output):
+async def test_ls_command(client,
+                          ssh_client, mocked_ssh_ls_output,
+                          cluster_name="cluster-slurm-ssh"):
 
     async with ssh_client.mocked_output([MockedCommand(**mocked_ssh_ls_output)]):
 
         response = client.get(
-            "/filesystem/cluster-slurm-ssh/ops/ls?path={path}".format(path="/home")
+            "/filesystem/{cluster_name}/ops/ls?path={path}".format(
+                cluster_name=cluster_name, path="/home"
+            )
         )
         assert response.status_code == 200
         assert response.json() is not None

--- a/tests/filesystem_ops_test.py
+++ b/tests/filesystem_ops_test.py
@@ -3,27 +3,12 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
-from importlib import resources as impresources
-import re
 from firecrest.filesystem.ops.models import File
-from tests import mocked_ssh_outputs
 import pytest
-import json
 
 from tests.helpers import load_ssh_output, helper_test_ls_command
 
 from tests.mock_ssh_client import MockedCommand
-
-
-# def load_ssh_output(file: str):
-#     output_file = impresources.files(mocked_ssh_outputs) / file
-#     with output_file.open("rb") as output:
-#         return json.load(output, strict=False)
-
-
-# @pytest.fixture(scope="module")
-# def mocked_ssh_ls_output():
-#     return load_ssh_output("ssh_ls_command.json")
 
 
 @pytest.fixture(scope="module")
@@ -135,7 +120,7 @@ async def test_ls_command(client,
                           ssh_client,
                           cluster_name="cluster-slurm-ssh"):
 
-    await helper_test_ls_command(client, ssh_client)
+    await helper_test_ls_command(client, ssh_client, cluster_name)
 
 
 async def test_ls_recursive_command(client, ssh_client, mocked_ssh_ls_recursive_output):

--- a/tests/health_check_test.py
+++ b/tests/health_check_test.py
@@ -14,6 +14,7 @@ from lib.auth.authN.OIDC_token_auth import OIDCTokenAuth
 from lib.models.apis.api_auth_model import ApiAuthModel
 from tests.mock_ssh_client import MockedCommand
 from tests import mocked_api_responses
+from firecrest.config import BackendServiceType
 
 # import helpers functions to avoid duplicating code in tests
 from tests.helpers import (
@@ -97,12 +98,12 @@ async def test_health_check_disabled(
 ):
 
     # storage probing is configured
-    assert "s3" in slurm_cluster_with_ssh_no_health_check_config.probing.services
+    assert BackendServiceType.external_storage in slurm_cluster_with_ssh_no_health_check_config.probing.services
 
     # ssh, scheduler and filesystem probing are not configured
-    assert "ssh" not in slurm_cluster_with_ssh_no_health_check_config.probing.services
-    assert "scheduler" not in slurm_cluster_with_ssh_no_health_check_config.probing.services
-    assert "filesystem" not in slurm_cluster_with_ssh_no_health_check_config.probing.services
+    assert BackendServiceType.ssh not in slurm_cluster_with_ssh_no_health_check_config.probing.services
+    assert BackendServiceType.scheduler not in slurm_cluster_with_ssh_no_health_check_config.probing.services
+    assert BackendServiceType.filesystem not in slurm_cluster_with_ssh_no_health_check_config.probing.services
 
 
 async def test_health_check_disabled_ok_with_ssh(
@@ -137,7 +138,7 @@ async def test_health_check_disabled_notok_with_filesystem(
 
         response = client.get(
             "/filesystem/{cluster_name}/ops/ls?path={path}".format(
-                cluster_name=slurm_cluster_with_ssh_no_health_check_config.name, path="/wrong_path"
+                cluster_name=slurm_cluster_with_ssh_no_health_check_config.name, path="/scratch"
             )
         )
 
@@ -151,3 +152,35 @@ async def test_health_check_disabled_ok_with_no_filesystem(
 
     await helper_test_ls_command(client, ssh_client,
                                  slurm_cluster_with_ssh_no_health_check_config.name)
+
+
+async def test_health_check_disabled_not_ok_traversal(
+    client, slurm_cluster_with_ssh_no_health_check_config
+):
+    response = client.get(
+        f"/filesystem/{slurm_cluster_with_ssh_no_health_check_config.name}"
+        "/ops/ls?path=/home/../etc/passwd"
+    )
+    assert response.status_code == 400
+
+
+async def test_health_check_enabled_on_wrong_path(
+    client, slurm_cluster_with_ssh_config
+):
+    response = client.get(
+        f"/filesystem/{slurm_cluster_with_ssh_config.name}"
+        "/ops/ls?path=/scratch"
+    )
+    assert response.status_code == 503
+
+
+async def test_health_check_relative_path(
+    client, slurm_cluster_with_ssh_config
+):
+    response = client.get(
+        f"/filesystem/{slurm_cluster_with_ssh_config.name}"
+        "/ops/ls?path=./home/fireuser"
+    )
+    assert response.status_code == 400
+
+

--- a/tests/health_check_test.py
+++ b/tests/health_check_test.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from importlib import resources as impresources
+from xmlrpc import client
 from firecrest.plugins import settings
 import json
 import pytest
@@ -14,12 +15,25 @@ from lib.auth.authN.OIDC_token_auth import OIDCTokenAuth
 from lib.models.apis.api_auth_model import ApiAuthModel
 from tests.mock_ssh_client import MockedCommand
 from tests import mocked_ssh_outputs, mocked_api_responses
+# import test functions from other test files to reuse them in this test
+from tests.compute_slurm_ssh_test import test_get_job
+from tests.filesystem_ops_test import test_ls_command
+from tests.status_test import test_userinfo
+# import mocked ssh outputs
+from tests.compute_slurm_ssh_test import mocked_ssh_sacct_output, mocked_ssh_squeue_output
+from tests.filesystem_ops_test import mocked_ssh_ls_output
+from tests.status_test import mocked_ssh_id_recursive_output, mocked_ssh_default_account_output, mocked_ssh_accounts_output
 
 
 def load_ssh_output(file: str):
     output_file = impresources.files(mocked_ssh_outputs) / file
     with output_file.open("rb") as output:
         return json.load(output, strict=False)
+
+
+@pytest.fixture(scope="module")
+def mocked_ssh_id_output():
+    return load_ssh_output("ssh_id_command.json")
 
 
 @pytest.fixture(scope="module")
@@ -36,27 +50,8 @@ def mocked_unhealthy_filesystem_response():
 
 
 @pytest.fixture(scope="module")
-def mocked_ssh_squeue_output():
-    output_file = impresources.files(mocked_ssh_outputs) / "ssh_squeue_command.json"
-    with output_file.open("rb") as output:
-        return json.load(output)
-
-
-@pytest.fixture(scope="module")
-def mocked_ssh_sacct_output():
-    output_file = impresources.files(mocked_ssh_outputs) / "ssh_sacct_command.json"
-    with output_file.open("rb") as output:
-        return json.load(output)
-
-
-@pytest.fixture(scope="module")
 def mocked_ssh_ls_wrong_path_output():
     return load_ssh_output("ssh_ls_command_wrong_path.json")
-
-
-@pytest.fixture(scope="module")
-def mocked_ssh_ls_output():
-    return load_ssh_output("ssh_ls_command.json")
 
 
 def mocked_token_response():
@@ -128,27 +123,31 @@ async def test_health_check_disabled(
 
 
 async def test_health_check_disabled_ok_with_ssh(
+    client,
+    ssh_client,
+    mocked_ssh_id_recursive_output,
+    mocked_ssh_default_account_output,
+    mocked_ssh_accounts_output,
+    slurm_cluster_with_ssh_config,
+):
+
+    await test_userinfo(client, ssh_client,
+                        mocked_ssh_id_recursive_output,
+                        mocked_ssh_default_account_output,
+                        mocked_ssh_accounts_output,
+                        slurm_cluster_with_ssh_config)
+
+
+async def test_health_check_disabled_ok_with_scheduler(
     client, ssh_client, 
     mocked_ssh_sacct_output,
     mocked_ssh_squeue_output,
     slurm_cluster_with_ssh_no_health_check_config,
 ):
-
-    async with ssh_client.mocked_output(
-        [
-            MockedCommand(**mocked_ssh_sacct_output),
-            MockedCommand(**mocked_ssh_squeue_output),
-        ]
-    ):
-        response = client.get(
-            "/compute/{cluster_name}/jobs/{job_id}".format(
-                cluster_name=slurm_cluster_with_ssh_no_health_check_config.name, job_id=1
-            )
-        )
-        assert response.status_code == 200
-        assert response.json() is not None
-
-        assert response.json()["jobs"][0]["status"]["exitCode"] == 0
+    await test_get_job(client, ssh_client,
+                       mocked_ssh_sacct_output,
+                       mocked_ssh_squeue_output,
+                       slurm_cluster_with_ssh_no_health_check_config)
 
 
 async def test_health_check_disabled_ok_with_filesystem(
@@ -171,16 +170,9 @@ async def test_health_check_disabled_ok_with_no_filesystem(
         client, ssh_client, mocked_ssh_ls_output,
         slurm_cluster_with_ssh_no_health_check_config,):
 
-    async with ssh_client.mocked_output([MockedCommand(**mocked_ssh_ls_output)]):
-
-        response = client.get(
-            "/filesystem/{cluster_name}/ops/ls?path={path}".format(
-                cluster_name=slurm_cluster_with_ssh_no_health_check_config.name, path="/home"
-            )
-        )
-
-        assert response.status_code == 200
-        assert response.json() is not None
+    await test_ls_command(client, ssh_client,
+                          mocked_ssh_ls_output,
+                          slurm_cluster_with_ssh_no_health_check_config.name)
 
 
 async def test_health_check_disabled_not_ok_transversal(

--- a/tests/health_check_test.py
+++ b/tests/health_check_test.py
@@ -184,3 +184,10 @@ async def test_health_check_relative_path(
     assert response.status_code == 400
 
 
+async def test_health_check_path_prefix_not_a_filesystem(
+    client, slurm_cluster_with_ssh_config
+):
+    response = client.get(
+        f"/filesystem/{slurm_cluster_with_ssh_config.name}/ops/ls?path=/home_private/x"
+    )
+    assert response.status_code == 400

--- a/tests/health_check_test.py
+++ b/tests/health_check_test.py
@@ -26,11 +26,6 @@ from tests.helpers import (
 
 
 @pytest.fixture(scope="module")
-def mocked_ssh_id_output():
-    return load_ssh_output("ssh_id_command.json")
-
-
-@pytest.fixture(scope="module")
 def mocked_nodes_get_response():
     response_file = impresources.files(mocked_api_responses) / "slurm_get_nodes.json"
     with response_file.open("r") as response:
@@ -156,19 +151,3 @@ async def test_health_check_disabled_ok_with_no_filesystem(
 
     await helper_test_ls_command(client, ssh_client,
                                  slurm_cluster_with_ssh_no_health_check_config.name)
-
-
-async def test_health_check_disabled_not_ok_traversal(
-        client, ssh_client,
-        slurm_cluster_with_ssh_no_health_check_config,):
-
-    async with ssh_client.mocked_output([MockedCommand(**mocked_ssh_ls_output())]):
-
-        response = client.get(
-            "/filesystem/{cluster_name}/ops/ls?path={path}".format(
-                cluster_name=slurm_cluster_with_ssh_no_health_check_config.name, path="/home/../etc/passwd"
-            )
-        )
-
-        assert response.status_code == 400
-        assert response.json() is not None

--- a/tests/health_check_test.py
+++ b/tests/health_check_test.py
@@ -12,7 +12,14 @@ from pytest_httpx import HTTPXMock
 from firecrest.status.health_check.health_checker_cluster import ClusterHealthChecker
 from lib.auth.authN.OIDC_token_auth import OIDCTokenAuth
 from lib.models.apis.api_auth_model import ApiAuthModel
-from tests import mocked_api_responses
+from tests.mock_ssh_client import MockedCommand
+from tests import mocked_ssh_outputs, mocked_api_responses
+
+
+def load_ssh_output(file: str):
+    output_file = impresources.files(mocked_ssh_outputs) / file
+    with output_file.open("rb") as output:
+        return json.load(output, strict=False)
 
 
 @pytest.fixture(scope="module")
@@ -20,6 +27,36 @@ def mocked_nodes_get_response():
     response_file = impresources.files(mocked_api_responses) / "slurm_get_nodes.json"
     with response_file.open("r") as response:
         return json.load(response)
+
+@pytest.fixture(scope="module")
+def mocked_unhealthy_filesystem_response():
+    response_file = impresources.files(mocked_api_responses) / "f7t_filesystem_not_healthy.json"
+    with response_file.open("r") as response:
+        return json.load(response)
+
+
+@pytest.fixture(scope="module")
+def mocked_ssh_squeue_output():
+    output_file = impresources.files(mocked_ssh_outputs) / "ssh_squeue_command.json"
+    with output_file.open("rb") as output:
+        return json.load(output)
+
+
+@pytest.fixture(scope="module")
+def mocked_ssh_sacct_output():
+    output_file = impresources.files(mocked_ssh_outputs) / "ssh_sacct_command.json"
+    with output_file.open("rb") as output:
+        return json.load(output)
+
+
+@pytest.fixture(scope="module")
+def mocked_ssh_ls_wrong_path_output():
+    return load_ssh_output("ssh_ls_command_wrong_path.json")
+
+
+@pytest.fixture(scope="module")
+def mocked_ssh_ls_output():
+    return load_ssh_output("ssh_ls_command.json")
 
 
 def mocked_token_response():
@@ -75,3 +112,88 @@ async def test_health_check(
         assert slurm_cluster_with_api_config.servicesHealth is not None
         assert isinstance(slurm_cluster_with_api_config.servicesHealth, list)
         assert len(slurm_cluster_with_api_config.servicesHealth) > 0
+
+
+async def test_health_check_disabled(
+    slurm_cluster_with_ssh_no_health_check_config,
+):
+
+    # storage probing is configured
+    assert "s3" in slurm_cluster_with_ssh_no_health_check_config.probing.services
+
+    # ssh, scheduler and filesystem probing are not configured
+    assert "ssh" not in slurm_cluster_with_ssh_no_health_check_config.probing.services
+    assert "scheduler" not in slurm_cluster_with_ssh_no_health_check_config.probing.services
+    assert "filesystem" not in slurm_cluster_with_ssh_no_health_check_config.probing.services
+
+
+async def test_health_check_disabled_ok_with_ssh(
+    client, ssh_client, 
+    mocked_ssh_sacct_output,
+    mocked_ssh_squeue_output,
+    slurm_cluster_with_ssh_no_health_check_config,
+):
+
+    async with ssh_client.mocked_output(
+        [
+            MockedCommand(**mocked_ssh_sacct_output),
+            MockedCommand(**mocked_ssh_squeue_output),
+        ]
+    ):
+        response = client.get(
+            "/compute/{cluster_name}/jobs/{job_id}".format(
+                cluster_name=slurm_cluster_with_ssh_no_health_check_config.name, job_id=1
+            )
+        )
+        assert response.status_code == 200
+        assert response.json() is not None
+
+        assert response.json()["jobs"][0]["status"]["exitCode"] == 0
+
+
+async def test_health_check_disabled_ok_with_filesystem(
+        client, ssh_client, mocked_ssh_ls_wrong_path_output,
+        slurm_cluster_with_ssh_no_health_check_config,):
+
+    async with ssh_client.mocked_output([MockedCommand(**mocked_ssh_ls_wrong_path_output)]):
+
+        response = client.get(
+            "/filesystem/{cluster_name}/ops/ls?path={path}".format(
+                cluster_name=slurm_cluster_with_ssh_no_health_check_config.name, path="/wrong_path"
+            )
+        )
+
+        assert response.status_code == 404
+        assert response.json() is not None
+
+
+async def test_health_check_disabled_ok_with_no_filesystem(
+        client, ssh_client, mocked_ssh_ls_output,
+        slurm_cluster_with_ssh_no_health_check_config,):
+
+    async with ssh_client.mocked_output([MockedCommand(**mocked_ssh_ls_output)]):
+
+        response = client.get(
+            "/filesystem/{cluster_name}/ops/ls?path={path}".format(
+                cluster_name=slurm_cluster_with_ssh_no_health_check_config.name, path="/home"
+            )
+        )
+
+        assert response.status_code == 200
+        assert response.json() is not None
+
+
+async def test_health_check_disabled_not_ok_transversal(
+        client, ssh_client, mocked_ssh_ls_output,
+        slurm_cluster_with_ssh_no_health_check_config,):
+
+    async with ssh_client.mocked_output([MockedCommand(**mocked_ssh_ls_output)]):
+
+        response = client.get(
+            "/filesystem/{cluster_name}/ops/ls?path={path}".format(
+                cluster_name=slurm_cluster_with_ssh_no_health_check_config.name, path="/home/../etc/passwd"
+            )
+        )
+
+        assert response.status_code == 400
+        assert response.json() is not None

--- a/tests/health_check_test.py
+++ b/tests/health_check_test.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from importlib import resources as impresources
-from xmlrpc import client
 from firecrest.plugins import settings
 import json
 import pytest
@@ -14,21 +13,16 @@ from firecrest.status.health_check.health_checker_cluster import ClusterHealthCh
 from lib.auth.authN.OIDC_token_auth import OIDCTokenAuth
 from lib.models.apis.api_auth_model import ApiAuthModel
 from tests.mock_ssh_client import MockedCommand
-from tests import mocked_ssh_outputs, mocked_api_responses
-# import test functions from other test files to reuse them in this test
-from tests.compute_slurm_ssh_test import test_get_job
-from tests.filesystem_ops_test import test_ls_command
-from tests.status_test import test_userinfo
-# import mocked ssh outputs
-from tests.compute_slurm_ssh_test import mocked_ssh_sacct_output, mocked_ssh_squeue_output
-from tests.filesystem_ops_test import mocked_ssh_ls_output
-from tests.status_test import mocked_ssh_id_recursive_output, mocked_ssh_default_account_output, mocked_ssh_accounts_output
+from tests import mocked_api_responses
 
-
-def load_ssh_output(file: str):
-    output_file = impresources.files(mocked_ssh_outputs) / file
-    with output_file.open("rb") as output:
-        return json.load(output, strict=False)
+# import helpers functions to avoid duplicating code in tests
+from tests.helpers import (
+    mocked_ssh_ls_output,
+    helper_test_userinfo,
+    helper_test_get_job,
+    helper_test_ls_command,
+    load_ssh_output,
+)
 
 
 @pytest.fixture(scope="module")
@@ -125,29 +119,25 @@ async def test_health_check_disabled(
 async def test_health_check_disabled_ok_with_ssh(
     client,
     ssh_client,
-    mocked_ssh_id_recursive_output,
-    mocked_ssh_default_account_output,
-    mocked_ssh_accounts_output,
-    slurm_cluster_with_ssh_config,
+    slurm_cluster_with_ssh_no_health_check_config,
 ):
 
-    await test_userinfo(client, ssh_client,
-                        mocked_ssh_id_recursive_output,
-                        mocked_ssh_default_account_output,
-                        mocked_ssh_accounts_output,
-                        slurm_cluster_with_ssh_config)
+    await helper_test_userinfo(
+        client,
+        ssh_client,
+        slurm_cluster_with_ssh_no_health_check_config.name
+    )
 
 
 async def test_health_check_disabled_ok_with_scheduler(
-    client, ssh_client, 
-    mocked_ssh_sacct_output,
-    mocked_ssh_squeue_output,
+    client, ssh_client,
     slurm_cluster_with_ssh_no_health_check_config,
 ):
-    await test_get_job(client, ssh_client,
-                       mocked_ssh_sacct_output,
-                       mocked_ssh_squeue_output,
-                       slurm_cluster_with_ssh_no_health_check_config)
+    await helper_test_get_job(
+        client,
+        ssh_client,
+        slurm_cluster_with_ssh_no_health_check_config.name
+    )
 
 
 async def test_health_check_disabled_ok_with_filesystem(
@@ -167,19 +157,18 @@ async def test_health_check_disabled_ok_with_filesystem(
 
 
 async def test_health_check_disabled_ok_with_no_filesystem(
-        client, ssh_client, mocked_ssh_ls_output,
+        client, ssh_client,
         slurm_cluster_with_ssh_no_health_check_config,):
 
-    await test_ls_command(client, ssh_client,
-                          mocked_ssh_ls_output,
-                          slurm_cluster_with_ssh_no_health_check_config.name)
+    await helper_test_ls_command(client, ssh_client,
+                                 slurm_cluster_with_ssh_no_health_check_config.name)
 
 
 async def test_health_check_disabled_not_ok_transversal(
-        client, ssh_client, mocked_ssh_ls_output,
+        client, ssh_client,
         slurm_cluster_with_ssh_no_health_check_config,):
 
-    async with ssh_client.mocked_output([MockedCommand(**mocked_ssh_ls_output)]):
+    async with ssh_client.mocked_output([MockedCommand(**mocked_ssh_ls_output())]):
 
         response = client.get(
             "/filesystem/{cluster_name}/ops/ls?path={path}".format(

--- a/tests/health_check_test.py
+++ b/tests/health_check_test.py
@@ -36,12 +36,6 @@ def mocked_nodes_get_response():
     with response_file.open("r") as response:
         return json.load(response)
 
-@pytest.fixture(scope="module")
-def mocked_unhealthy_filesystem_response():
-    response_file = impresources.files(mocked_api_responses) / "f7t_filesystem_not_healthy.json"
-    with response_file.open("r") as response:
-        return json.load(response)
-
 
 @pytest.fixture(scope="module")
 def mocked_ssh_ls_wrong_path_output():
@@ -140,7 +134,7 @@ async def test_health_check_disabled_ok_with_scheduler(
     )
 
 
-async def test_health_check_disabled_ok_with_filesystem(
+async def test_health_check_disabled_notok_with_filesystem(
         client, ssh_client, mocked_ssh_ls_wrong_path_output,
         slurm_cluster_with_ssh_no_health_check_config,):
 
@@ -164,7 +158,7 @@ async def test_health_check_disabled_ok_with_no_filesystem(
                                  slurm_cluster_with_ssh_no_health_check_config.name)
 
 
-async def test_health_check_disabled_not_ok_transversal(
+async def test_health_check_disabled_not_ok_traversal(
         client, ssh_client,
         slurm_cluster_with_ssh_no_health_check_config,):
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2026, ETH Zurich. All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+
+from importlib import resources as impresources
+import json
+
+from tests import mocked_ssh_outputs
+from tests.mock_ssh_client import MockedCommand
+from firecrest.status.models import UserInfoResponse
+
+
+def load_ssh_output(file: str):
+    output_file = impresources.files(mocked_ssh_outputs) / file
+    with output_file.open("rb") as output:
+        return json.load(output, strict=False)
+
+
+def mocked_ssh_ls_output():
+    return load_ssh_output("ssh_ls_command.json")
+
+
+def mocked_ssh_sacct_output():
+    output_file = impresources.files(mocked_ssh_outputs) / "ssh_sacct_command.json"
+    with output_file.open("rb") as output:
+        return json.load(output)
+
+
+def mocked_ssh_squeue_output():
+    output_file = impresources.files(mocked_ssh_outputs) / "ssh_squeue_command.json"
+    with output_file.open("rb") as output:
+        return json.load(output)
+
+
+def mocked_ssh_id_recursive_output():
+    return load_ssh_output("ssh_id_command.json")
+
+
+def mocked_ssh_default_account_output():
+    return load_ssh_output("ssh_sacctmgr_default_account.json")
+
+
+def mocked_ssh_accounts_output():
+    return load_ssh_output("ssh_sacctmgr_accounts.json")
+
+
+# Test helper functions
+
+async def helper_test_userinfo(
+    client,
+    ssh_client,
+    cluster_name: str,    
+):
+
+    async with ssh_client.mocked_output(
+        [
+            MockedCommand(**mocked_ssh_id_recursive_output()),
+            MockedCommand(**mocked_ssh_default_account_output()),
+            MockedCommand(**mocked_ssh_accounts_output()),
+        ]
+    ):
+        response = client.get(f"/status/{cluster_name}/userinfo")
+        assert response.status_code == 200
+        assert UserInfoResponse(**response.json()) is not None
+
+
+async def helper_test_get_job(
+    client,
+    ssh_client,
+    cluster_name: str,
+):
+
+    async with ssh_client.mocked_output(
+        [
+            MockedCommand(**mocked_ssh_sacct_output()),
+            MockedCommand(**mocked_ssh_squeue_output()),
+        ]
+    ):
+        response = client.get(f"/compute/{cluster_name}/jobs/1")
+
+        assert response.status_code == 200
+        assert response.json() is not None
+
+        assert response.json()["jobs"][0]["status"]["exitCode"] == 0
+
+
+async def helper_test_ls_command(client,
+                                 ssh_client,
+                                 cluster_name="cluster-slurm-ssh",
+                                 path="/home"):
+
+    async with ssh_client.mocked_output([MockedCommand(**mocked_ssh_ls_output())]):
+
+        response = client.get(
+            f"/filesystem/{cluster_name}/ops/ls?path={path}"
+        )
+        assert response.status_code == 200
+        assert response.json() is not None
+        assert len(response.json()["output"]) == 4

--- a/tests/mocked_ssh_outputs/ssh_ls_command_wrong_path.json
+++ b/tests/mocked_ssh_outputs/ssh_ls_command_wrong_path.json
@@ -1,0 +1,8 @@
+{
+    "stdout": "",
+    "stderr": "ls: cannot access '/wrong_path': No such file or directory",
+    "exit_code": 2,
+    "command":"ls -l --quoting-style=c --time-style='+%Y-%m-%dT%H:%M:%S' -- '/wrong_path'"
+
+}
+

--- a/tests/mocked_ssh_outputs/ssh_ls_command_wrong_path.json
+++ b/tests/mocked_ssh_outputs/ssh_ls_command_wrong_path.json
@@ -1,8 +1,8 @@
 {
     "stdout": "",
-    "stderr": "ls: cannot access '/wrong_path': No such file or directory",
+    "stderr": "ls: cannot access '/scratch': No such file or directory",
     "exit_code": 2,
-    "command":"ls -l --quoting-style=c --time-style='+%Y-%m-%dT%H:%M:%S' -- '/wrong_path'"
+    "command":"ls -l --quoting-style=c --time-style='+%Y-%m-%dT%H:%M:%S' -- '/scratch'"
 
 }
 

--- a/tests/status_test.py
+++ b/tests/status_test.py
@@ -11,8 +11,7 @@ import aiohttp
 from firecrest.status.models import (
     GetNodesResponse,
     GetPartitionsResponse,
-    GetReservationsResponse,
-    UserInfoResponse,
+    GetReservationsResponse,    
 )
 
 from importlib import resources as impresources
@@ -24,6 +23,8 @@ from aioresponses import aioresponses
 
 from firecrest.config import HPCCluster, Scheduler
 from tests.filesystem_ops_test import load_ssh_output
+
+from tests.helpers import helper_test_userinfo
 
 
 @pytest.fixture(scope="module")
@@ -213,22 +214,14 @@ def test_systems_reservations(
 async def test_userinfo(
     client,
     ssh_client,
-    mocked_ssh_id_recursive_output,
-    mocked_ssh_default_account_output,
-    mocked_ssh_accounts_output,
     slurm_cluster_with_ssh_config,
 ):
 
-    async with ssh_client.mocked_output(
-        [
-            MockedCommand(**mocked_ssh_id_recursive_output),
-            MockedCommand(**mocked_ssh_default_account_output),
-            MockedCommand(**mocked_ssh_accounts_output),
-        ]
-    ):
-        response = client.get(f"/status/{slurm_cluster_with_ssh_config.name}/userinfo")
-        assert response.status_code == 200
-        assert UserInfoResponse(**response.json()) is not None
+    await helper_test_userinfo(
+        client,
+        ssh_client,
+        cluster_name=slurm_cluster_with_ssh_config.name,        
+    )
 
 
 async def test_ssh_reservation(

--- a/tests/status_test.py
+++ b/tests/status_test.py
@@ -22,9 +22,8 @@ import pytest
 from aioresponses import aioresponses
 
 from firecrest.config import HPCCluster, Scheduler
-from tests.filesystem_ops_test import load_ssh_output
 
-from tests.helpers import helper_test_userinfo
+from tests.helpers import helper_test_userinfo, load_ssh_output
 
 
 @pytest.fixture(scope="module")
@@ -53,11 +52,6 @@ def mocked_get_partitions_response():
 
 
 @pytest.fixture(scope="module")
-def mocked_ssh_id_recursive_output():
-    return load_ssh_output("ssh_id_command.json")
-
-
-@pytest.fixture(scope="module")
 def mocked_ssh_reservation_output():
     return load_ssh_output("ssh_scontrol_reservation_command.json")
 
@@ -65,16 +59,6 @@ def mocked_ssh_reservation_output():
 @pytest.fixture(scope="module")
 def mocked_ssh_partitions_output():
     return load_ssh_output("ssh_scontrol_partitions.json")
-
-
-@pytest.fixture(scope="module")
-def mocked_ssh_default_account_output():
-    return load_ssh_output("ssh_sacctmgr_default_account.json")
-
-
-@pytest.fixture(scope="module")
-def mocked_ssh_accounts_output():
-    return load_ssh_output("ssh_sacctmgr_accounts.json")
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
This PR fixes backend command execution when the health check is disabled. The service(s) (`ssh`, `scheduler`, and `filesystems`) will try to execute commands without expecting the service to be healthy.
Also, it includes a check on the `path` to avoid using filesystems not listed in the `system.file_systems` setting.