### PR TITLE
Hot fix: enable trace logging on request and response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
 ## [2.5.5] - OPEN
+
+
+### Added
+
+- Trace logs now include both request and response trace.
+
 
 ### Fixed
 
 - Fixes truncation of `workingDirectory` in job responses for running/pending jobs caused by `squeue`'s default 20-character column width.
 - Fixes error handling of downstream services.
+- Fixes log tracing
 
 ## [2.5.4]
 

--- a/src/firecrest/main.py
+++ b/src/firecrest/main.py
@@ -146,7 +146,6 @@ def register_middlewares(app: FastAPI):
         logging.getLogger("uvicorn.access").addFilter(EndpointFilter())
 
         try:
-
             # Logging from Middleware request
             if settings.logger.enable_tracing_log:
                 tracing_log_middleware(
@@ -157,15 +156,16 @@ def register_middlewares(app: FastAPI):
                 )
 
             response = await call_next(request)
-            username = None
-            if hasattr(request.state, "username"):
-                username = request.state.username
 
             # Logging from Middleware response
             if settings.logger.enable_tracing_log:
                 tracing_log_middleware(
                     request,
-                    username,
+                    (
+                        request.state.username
+                        if hasattr(request.state, "username")
+                        else None
+                    ),
                     response.status_code,
                     settings.logger.loggable_request_headers,
                 )

--- a/src/firecrest/main.py
+++ b/src/firecrest/main.py
@@ -146,11 +146,23 @@ def register_middlewares(app: FastAPI):
         logging.getLogger("uvicorn.access").addFilter(EndpointFilter())
 
         try:
-            response = await call_next(request)
+
             username = None
             if hasattr(request.state, "username"):
                 username = request.state.username
-            # Logging from Middleware
+
+            # Logging from Middleware request
+            if settings.logger.enable_tracing_log:
+                tracing_log_middleware(
+                    request,
+                    username,
+                    None,
+                    settings.logger.loggable_request_headers,
+                )
+
+            response = await call_next(request)
+
+            # Logging from Middleware response
             if settings.logger.enable_tracing_log:
                 tracing_log_middleware(
                     request,

--- a/src/firecrest/main.py
+++ b/src/firecrest/main.py
@@ -147,20 +147,19 @@ def register_middlewares(app: FastAPI):
 
         try:
 
-            username = None
-            if hasattr(request.state, "username"):
-                username = request.state.username
-
             # Logging from Middleware request
             if settings.logger.enable_tracing_log:
                 tracing_log_middleware(
                     request,
-                    username,
+                    None,
                     None,
                     settings.logger.loggable_request_headers,
                 )
 
             response = await call_next(request)
+            username = None
+            if hasattr(request.state, "username"):
+                username = request.state.username
 
             # Logging from Middleware response
             if settings.logger.enable_tracing_log:

--- a/src/lib/loggers/tracing_log.py
+++ b/src/lib/loggers/tracing_log.py
@@ -10,9 +10,11 @@ import logging
 from functools import wraps
 from fastapi import Request
 from starlette_context import context
+from starlette_context.header_keys import HeaderKeys
 
 # The actual tracing logger
 tracing_logger = logging.getLogger("f7t_v2_tracing_log")
+
 
 # Wrapper
 def tracing_log_method(func):
@@ -62,7 +64,9 @@ def log_backend_http_scheduler(url: str, response_status: int) -> None:
 
 
 @tracing_log_method
-def tracing_log_middleware(request: Request, username: str, status_code: int, headers_to_trace: list) -> None:
+def tracing_log_middleware(
+    request: Request, username: str, status_code: int, headers_to_trace: list
+) -> None:
     # Get URL
     url_path = request.scope["path"]
     root_path = request.scope["root_path"]
@@ -87,11 +91,13 @@ def tracing_log_middleware(request: Request, username: str, status_code: int, he
     log_data["endpoint"] = endpoint
     log_data["resource"] = resource
     log_data["status_code"] = status_code
-    
+    log_data["trace_Id"] = get_tracing_data(HeaderKeys.correlation_id)
+    log_data["request_Id"] = get_tracing_data(HeaderKeys.request_id)
+
     for header in headers_to_trace:
-        if header['input'] in request.headers:
-            log_data[header['output']] = request.headers[header['input']]
-    
+        if header["input"] in request.headers:
+            log_data[header["output"]] = request.headers[header["input"]]
+
     # Get backend log if any
     backend = get_tracing_backend_log()
     if backend is not None:

--- a/src/lib/loggers/tracing_log.py
+++ b/src/lib/loggers/tracing_log.py
@@ -91,8 +91,8 @@ def tracing_log_middleware(
     log_data["endpoint"] = endpoint
     log_data["resource"] = resource
     log_data["status_code"] = status_code
-    log_data["trace_Id"] = get_tracing_data(HeaderKeys.correlation_id)
-    log_data["request_Id"] = get_tracing_data(HeaderKeys.request_id)
+    log_data["trace_id"] = get_tracing_data(HeaderKeys.correlation_id)
+    log_data["request_id"] = get_tracing_data(HeaderKeys.request_id)
 
     for header in headers_to_trace:
         if header["input"] in request.headers:


### PR DESCRIPTION
We want to track the time of incoming requests and outgoing responses.