### PR TITLE
fixed scheduler not taking SSH setting when restapi url is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Allow command execution when the health check is disabled
+- Scheduler in connection mode `ssh` was skipped when RESTAPI `url` option was set.
 
 ## [2.5.5]
 

--- a/src/firecrest/dependencies.py
+++ b/src/firecrest/dependencies.py
@@ -325,6 +325,7 @@ class SchedulerClientDependency:
                     system.scheduler.api_url,
                     system.scheduler.timeout,
                     settings.auth.authentication.username_claim,
+                    system.scheduler.connection_mode,
                 )
             case SchedulerType.pbs:
                 return PbsClient(

--- a/src/lib/scheduler_clients/slurm/slurm_client.py
+++ b/src/lib/scheduler_clients/slurm/slurm_client.py
@@ -30,7 +30,7 @@ class SlurmClient(SlurmBaseClient):
         api_url: str | None,
         timeout: int | None,
         username_claim: str | None,
-        connection_mode: str = SchedulerConnectionMode.ssh.value
+        connection_mode: SchedulerConnectionMode = SchedulerConnectionMode.ssh
     ):
 
         self.ssh_client = ssh_client
@@ -46,7 +46,7 @@ class SlurmClient(SlurmBaseClient):
         if ssh_client:
             self.slurm_cli_client = SlurmCliClient(ssh_client, slurm_version)
 
-        if self.connection_mode != SchedulerConnectionMode.ssh.value:
+        if self.connection_mode != SchedulerConnectionMode.ssh:
             self.slurm_rest_client = SlurmRestClient(
                 api_url, api_version, timeout, username_claim
             )

--- a/src/lib/scheduler_clients/slurm/slurm_client.py
+++ b/src/lib/scheduler_clients/slurm/slurm_client.py
@@ -15,6 +15,7 @@ from lib.scheduler_clients.slurm.models import (
 from lib.scheduler_clients.slurm.slurm_base_client import SlurmBaseClient
 from lib.scheduler_clients.slurm.slurm_cli_client import SlurmCliClient
 from lib.scheduler_clients.slurm.slurm_rest_client import SlurmRestClient
+from firecrest.config import SchedulerConnectionMode
 
 from lib.ssh_clients.ssh_client import SSHClientPool
 
@@ -29,6 +30,7 @@ class SlurmClient(SlurmBaseClient):
         api_url: str | None,
         timeout: int | None,
         username_claim: str | None,
+        connection_mode: str = SchedulerConnectionMode.ssh.value
     ):
 
         self.ssh_client = ssh_client
@@ -37,13 +39,14 @@ class SlurmClient(SlurmBaseClient):
         self.slurm_version = slurm_version
         self.api_version = api_version
         self.username_claim = username_claim
+        self.connection_mode = connection_mode
 
         self.slurm_cli_client = None
 
         if ssh_client:
             self.slurm_cli_client = SlurmCliClient(ssh_client, slurm_version)
 
-        if self.api_url:
+        if self.connection_mode != SchedulerConnectionMode.ssh.value:
             self.slurm_rest_client = SlurmRestClient(
                 api_url, api_version, timeout, username_claim
             )


### PR DESCRIPTION
In the `scheduler` settings, when `connection_mode: ssh`, if the URL of the REST API was set, the SSH connection was skipped, and only REST was used. 

This PR checks that if the `restapi` is used only if `ssh` mode is not set.