### PR TITLE
Added name parameter for job filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `jobname` parameter in `GET /compute/jobs` request
+- `name` parameter in `GET /compute/jobs` request
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.5.6] - OPEN
+## [2.5.7] - OPEN
+
+### Added
+
+- `jobname` parameter in `GET /compute/jobs` request
+
+### Changed
+
+### Fixed
+
+## [2.5.6]
 
 ### Added
 

--- a/src/firecrest/compute/router.py
+++ b/src/firecrest/compute/router.py
@@ -89,11 +89,16 @@ async def get_jobs(
         str | None,
         Query(description="If specified, filter jobs by account name"),
     ] = None,
+    name: Annotated[
+        str | None,
+        Query(description="If specified, filter jobs by name"),
+    ] = None,
 ) -> Any:
     username = ApiAuthHelper.get_auth().username
     access_token = ApiAuthHelper.get_access_token()
     jobs = await scheduler_client.get_jobs(
-        username=username, jwt_token=access_token, allusers=allusers, account=account
+        username=username, jwt_token=access_token, allusers=allusers,
+        account=account, name=name
     )
     return {"jobs": jobs}
 

--- a/src/firecrest/compute/router.py
+++ b/src/firecrest/compute/router.py
@@ -91,7 +91,9 @@ async def get_jobs(
     ] = None,
     name: Annotated[
         str | None,
-        Query(description="If specified, filter jobs by name"),
+        Query(description="If specified, filter jobs by name",
+              max_length=1024,
+              pattern="^[A-Za-z0-9][A-Za-z0-9+.\\-_]{0,235}$"),
     ] = None,
 ) -> Any:
     username = ApiAuthHelper.get_auth().username

--- a/src/firecrest/compute/router.py
+++ b/src/firecrest/compute/router.py
@@ -91,9 +91,7 @@ async def get_jobs(
     ] = None,
     name: Annotated[
         str | None,
-        Query(description="If specified, filter jobs by name",
-              max_length=1024,
-              pattern="^[A-Za-z0-9][A-Za-z0-9+.\\-_]{0,235}$"),
+        Query(description="If specified, filter jobs by name", max_length=235)  # length based on OpenPBS
     ] = None,
 ) -> Any:
     username = ApiAuthHelper.get_auth().username

--- a/src/lib/scheduler_clients/pbs/cli_commands/qstat_base.py
+++ b/src/lib/scheduler_clients/pbs/cli_commands/qstat_base.py
@@ -15,17 +15,17 @@ class QstatBaseCommand(BaseCommand):
         ids: Optional[List[str]] = None,
         allusers: bool = True,
         account: str = None,
+        name: str = None,
     ) -> None:
         super().__init__()
         self.username = username
         self.ids = ids if ids else []
         self.allusers = allusers
         self.account = account
+        self.name = name
 
     def get_command(self) -> str:
         cmd = ["qstat", "-F", "json", "-f"] + self.ids
-        if self.account:
-            cmd += ["-A", self.account]
         return " ".join(cmd)
 
     def parse_output(self, stdout: str, stderr: str, exit_status: int = 0):

--- a/src/lib/scheduler_clients/pbs/cli_commands/qstat_base.py
+++ b/src/lib/scheduler_clients/pbs/cli_commands/qstat_base.py
@@ -26,6 +26,7 @@ class QstatBaseCommand(BaseCommand):
 
     def get_command(self) -> str:
         cmd = ["qstat", "-F", "json", "-f"] + self.ids
+        # removed the -A options, since is not an option in qstat command
         return " ".join(cmd)
 
     def parse_output(self, stdout: str, stderr: str, exit_status: int = 0):

--- a/src/lib/scheduler_clients/pbs/cli_commands/qstat_base.py
+++ b/src/lib/scheduler_clients/pbs/cli_commands/qstat_base.py
@@ -26,7 +26,8 @@ class QstatBaseCommand(BaseCommand):
 
     def get_command(self) -> str:
         cmd = ["qstat", "-F", "json", "-f"] + self.ids
-        # removed the -A options, since is not an option in qstat command
+        # removed the -A options, since it is not an option in qstat command,
+        # then the account filtering is done on the client-side
         return " ".join(cmd)
 
     def parse_output(self, stdout: str, stderr: str, exit_status: int = 0):

--- a/src/lib/scheduler_clients/pbs/cli_commands/qstat_command.py
+++ b/src/lib/scheduler_clients/pbs/cli_commands/qstat_command.py
@@ -41,6 +41,16 @@ class QstatCommand(QstatBaseCommand):
             if not self.allusers and job_owner != self.username:
                 continue
 
+            if self.name:
+                name = job_data.get("Job_Name", "")
+                if name != self.name:
+                    continue
+
+            if self.account:
+                account = job_data.get("project", "")
+                if account != self.account:
+                    continue
+
             # job_id examples:
             #  "123456.pbs"
             #  "123456[].pbs"

--- a/src/lib/scheduler_clients/pbs/pbs_client.py
+++ b/src/lib/scheduler_clients/pbs/pbs_client.py
@@ -109,9 +109,10 @@ class PbsClient(SchedulerBaseClient):
         return result
 
     async def get_jobs(
-        self, username: str, jwt_token: str, allusers: bool = False, account: str = None
+        self, username: str, jwt_token: str, allusers: bool = False,
+        account: str = None, name: str = None,
     ) -> List[PbsJob] | None:
-        qstat = QstatCommand(username, None, allusers, account)
+        qstat = QstatCommand(username, None, allusers, account, name)
         result = await self.__executed_ssh_cmd(username, jwt_token, qstat)
         # Apply PBS model
         if result:

--- a/src/lib/scheduler_clients/scheduler_base_client.py
+++ b/src/lib/scheduler_clients/scheduler_base_client.py
@@ -55,7 +55,8 @@ class SchedulerBaseClient(ABC):
 
     @abstractmethod
     async def get_jobs(
-        self, username: str, jwt_token: str, allusers: bool = False
+        self, username: str, jwt_token: str, allusers: bool = False,
+        name: str = None,
     ) -> List[JobModel] | None:
         pass
 

--- a/src/lib/scheduler_clients/scheduler_base_client.py
+++ b/src/lib/scheduler_clients/scheduler_base_client.py
@@ -56,7 +56,7 @@ class SchedulerBaseClient(ABC):
     @abstractmethod
     async def get_jobs(
         self, username: str, jwt_token: str, allusers: bool = False,
-        name: str = None,
+        account: str = None, name: str = None,
     ) -> List[JobModel] | None:
         pass
 

--- a/src/lib/scheduler_clients/slurm/cli_commands/sacct_base.py
+++ b/src/lib/scheduler_clients/slurm/cli_commands/sacct_base.py
@@ -17,12 +17,14 @@ class SacctCommandBase(BaseCommand):
         job_ids: List[str] = None,
         allusers: bool = False,
         account: str = None,
+        name: str = None,
     ) -> None:
         super().__init__()
         self.username = username
         self.allusers = allusers
         self.job_ids = job_ids
         self.account = account
+        self.name = name
 
     def get_command(self) -> str:
         cmd = ["SLURM_TIME_FORMAT='%s' sacct"]
@@ -30,6 +32,8 @@ class SacctCommandBase(BaseCommand):
             cmd += ["--allusers"]
         if self.account:
             cmd += [f"--account='{self.account}'"]
+        if self.name:
+            cmd += [f"--name='{self.name}'"]
         if self.job_ids:
             str_job_ids = ",".join(self.job_ids)
             cmd += [f"--jobs='{str_job_ids}'"]
@@ -38,6 +42,7 @@ class SacctCommandBase(BaseCommand):
                 "--starttime=now-7days"
             ]  # up to one week ago, default is since midnight today
         cmd += ["--parsable2"]
+        print(" ".join(cmd))
         return " ".join(cmd)
 
     @abstractmethod

--- a/src/lib/scheduler_clients/slurm/cli_commands/sacct_base.py
+++ b/src/lib/scheduler_clients/slurm/cli_commands/sacct_base.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 # commands
+import shlex
 from abc import abstractmethod
 from typing import List
 from lib.ssh_clients.ssh_client import BaseCommand
@@ -31,18 +32,17 @@ class SacctCommandBase(BaseCommand):
         if self.allusers:
             cmd += ["--allusers"]
         if self.account:
-            cmd += [f"--account='{self.account}'"]
+            cmd += [f"--account={shlex.quote(self.account)}"]
         if self.name:
-            cmd += [f"--name='{self.name}'"]
+            cmd += [f"--name={shlex.quote(self.name)}"]
         if self.job_ids:
             str_job_ids = ",".join(self.job_ids)
-            cmd += [f"--jobs='{str_job_ids}'"]
+            cmd += [f"--jobs={shlex.quote(str_job_ids)}"]
         else:
             cmd += [
                 "--starttime=now-7days"
             ]  # up to one week ago, default is since midnight today
         cmd += ["--parsable2"]
-        print(" ".join(cmd))
         return " ".join(cmd)
 
     @abstractmethod

--- a/src/lib/scheduler_clients/slurm/cli_commands/squeue_command.py
+++ b/src/lib/scheduler_clients/slurm/cli_commands/squeue_command.py
@@ -40,7 +40,6 @@ class SqueueCommand(SacctCommand):
             "--noheader",
             "--Format='JobID:|,NumNodes:|,Cluster:||,GroupName:|,Account:|,Name:|,NodeList:|,Partition:|,PriorityLong:|,State:|,Reason:|,TimeUsed:|,SubmitTime:|,StartTime:|,EndTime:||,TimeLimit:|,UserName:|,WorkDir:'",
         ]
-        print(" ".join(cmd))
         return " ".join(cmd)
 
     def parse_output(self, stdout: str, stderr: str, exit_status: int = 0):

--- a/src/lib/scheduler_clients/slurm/cli_commands/squeue_command.py
+++ b/src/lib/scheduler_clients/slurm/cli_commands/squeue_command.py
@@ -16,12 +16,14 @@ class SqueueCommand(SacctCommand):
         job_ids: List[str] = None,
         allusers: bool = False,
         account: str = None,
+        name: str = None,
     ) -> None:
         super().__init__()
         self.username = username
         self.allusers = allusers
         self.job_ids = job_ids
         self.account = account
+        self.name = name
 
     def get_command(self) -> str:
         cmd = ["SLURM_TIME_FORMAT='%s' squeue"]
@@ -29,6 +31,8 @@ class SqueueCommand(SacctCommand):
             cmd += [f"--user='{self.username}'"]  # show only user jobs
         if self.account:
             cmd += [f"--account='{self.account}'"]
+        if self.name:
+            cmd += [f"--name='{self.name}'"]
         if self.job_ids:
             str_job_ids = ",".join(self.job_ids)
             cmd += [f"--jobs='{str_job_ids}'"]
@@ -36,6 +40,7 @@ class SqueueCommand(SacctCommand):
             "--noheader",
             "--Format='JobID:|,NumNodes:|,Cluster:||,GroupName:|,Account:|,Name:|,NodeList:|,Partition:|,PriorityLong:|,State:|,Reason:|,TimeUsed:|,SubmitTime:|,StartTime:|,EndTime:||,TimeLimit:|,UserName:|,WorkDir:'",
         ]
+        print(" ".join(cmd))
         return " ".join(cmd)
 
     def parse_output(self, stdout: str, stderr: str, exit_status: int = 0):

--- a/src/lib/scheduler_clients/slurm/cli_commands/squeue_command.py
+++ b/src/lib/scheduler_clients/slurm/cli_commands/squeue_command.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 # commands
+import shlex
 from typing import List
 from lib.scheduler_clients.slurm.cli_commands.sacct_job_info_command import SacctCommand
 
@@ -18,24 +19,26 @@ class SqueueCommand(SacctCommand):
         account: str = None,
         name: str = None,
     ) -> None:
-        super().__init__()
-        self.username = username
-        self.allusers = allusers
-        self.job_ids = job_ids
-        self.account = account
-        self.name = name
+        super().__init__(
+            username,
+            job_ids,
+            allusers,
+            account,
+            name
+        )
 
     def get_command(self) -> str:
         cmd = ["SLURM_TIME_FORMAT='%s' squeue"]
+        print(f"Name: {self.name}")
         if not self.allusers:
             cmd += [f"--user='{self.username}'"]  # show only user jobs
         if self.account:
-            cmd += [f"--account='{self.account}'"]
+            cmd += [f"--account={shlex.quote(self.account)}"]
         if self.name:
-            cmd += [f"--name='{self.name}'"]
+            cmd += [f"--name={shlex.quote(self.name)}"]
         if self.job_ids:
             str_job_ids = ",".join(self.job_ids)
-            cmd += [f"--jobs='{str_job_ids}'"]
+            cmd += [f"--jobs={shlex.quote(str_job_ids)}"]
         cmd += [
             "--noheader",
             "--Format='JobID:|,NumNodes:|,Cluster:||,GroupName:|,Account:|,Name:|,NodeList:|,Partition:|,PriorityLong:|,State:|,Reason:|,TimeUsed:|,SubmitTime:|,StartTime:|,EndTime:||,TimeLimit:|,UserName:|,WorkDir:'",

--- a/src/lib/scheduler_clients/slurm/cli_commands/squeue_command.py
+++ b/src/lib/scheduler_clients/slurm/cli_commands/squeue_command.py
@@ -29,9 +29,8 @@ class SqueueCommand(SacctCommand):
 
     def get_command(self) -> str:
         cmd = ["SLURM_TIME_FORMAT='%s' squeue"]
-        print(f"Name: {self.name}")
         if not self.allusers:
-            cmd += [f"--user='{self.username}'"]  # show only user jobs
+            cmd += [f"--user={shlex.quote(self.username)}"]  # show only user jobs
         if self.account:
             cmd += [f"--account={shlex.quote(self.account)}"]
         if self.name:

--- a/src/lib/scheduler_clients/slurm/models.py
+++ b/src/lib/scheduler_clients/slurm/models.py
@@ -193,10 +193,11 @@ class SlurmJob(JobModel):
         # Custom nodes count extraction
         if "allocation_nodes" not in kwargs and "job_resources" in kwargs:
             if kwargs["job_resources"] and "nodes" in kwargs["job_resources"]:
-                if "count" in kwargs["job_resources"]["nodes"]:
-                    kwargs["allocation_nodes"] = kwargs["job_resources"]["nodes"]["count"]
+                nodes = kwargs["job_resources"]["nodes"]
+                if isinstance(nodes, dict):
+                    kwargs["allocation_nodes"] = nodes.get("count", 0)
                 else:
-                    kwargs["allocation_nodes"] = kwargs["job_resources"]["allocated_hosts"]
+                    kwargs["allocation_nodes"] = kwargs["job_resources"].get("allocated_hosts", 0)
             else:
                 kwargs["allocation_nodes"] = 0
 

--- a/src/lib/scheduler_clients/slurm/models.py
+++ b/src/lib/scheduler_clients/slurm/models.py
@@ -193,7 +193,10 @@ class SlurmJob(JobModel):
         # Custom nodes count extraction
         if "allocation_nodes" not in kwargs and "job_resources" in kwargs:
             if kwargs["job_resources"] and "nodes" in kwargs["job_resources"]:
-                kwargs["allocation_nodes"] = kwargs["job_resources"]["nodes"]["count"]
+                if "count" in kwargs["job_resources"]["nodes"]:
+                    kwargs["allocation_nodes"] = kwargs["job_resources"]["nodes"]["count"]
+                else:
+                    kwargs["allocation_nodes"] = kwargs["job_resources"]["allocated_hosts"]
             else:
                 kwargs["allocation_nodes"] = 0
 

--- a/src/lib/scheduler_clients/slurm/slurm_base_client.py
+++ b/src/lib/scheduler_clients/slurm/slurm_base_client.py
@@ -59,7 +59,8 @@ class SlurmBaseClient(SchedulerBaseClient):
 
     @abstractmethod
     async def get_jobs(
-        self, username: str, jwt_token: str, allusers: bool = False, account: str = None
+        self, username: str, jwt_token: str, allusers: bool = False,
+        account: str = None, name: str = None,
     ) -> List[SlurmJob] | None:
         pass
 

--- a/src/lib/scheduler_clients/slurm/slurm_cli_client.py
+++ b/src/lib/scheduler_clients/slurm/slurm_cli_client.py
@@ -175,10 +175,11 @@ class SlurmCliClient(SlurmBaseClient):
         return jobs
 
     async def get_jobs(
-        self, username: str, jwt_token: str, allusers: bool = False, account: str = None
+        self, username: str, jwt_token: str, allusers: bool = False,
+        account: str = None, name: str = None
     ) -> List[SlurmJob] | None:
-        sacct = SacctCommand(username, None, allusers, account)
-        squeue = SqueueCommand(username, None, allusers, account)
+        sacct = SacctCommand(username, None, allusers, account, name)
+        squeue = SqueueCommand(username, None, allusers, account, name)
 
         commands = [
             # sacct has precedence over squeue, as it contains more complete job info, including finished jobs

--- a/src/lib/scheduler_clients/slurm/slurm_client.py
+++ b/src/lib/scheduler_clients/slurm/slurm_client.py
@@ -91,10 +91,11 @@ class SlurmClient(SlurmBaseClient):
         )
 
     async def get_jobs(
-        self, username: str, jwt_token: str, allusers: bool = False, account: str = None
+        self, username: str, jwt_token: str, allusers: bool = False,
+        account: str = None, name: str = None
     ) -> List[SlurmJob] | None:
         return await self.slurm_default_client.get_jobs(
-            username, jwt_token, allusers, account
+            username, jwt_token, allusers, account, name
         )
 
     async def get_job_metadata(

--- a/src/lib/scheduler_clients/slurm/slurm_rest_client.py
+++ b/src/lib/scheduler_clients/slurm/slurm_rest_client.py
@@ -220,8 +220,6 @@ class SlurmRestClient(SlurmBaseClient):
         query_list = []
         if account:
             query_list.append(f"{urllib.parse.urlencode({'account': account})}")
-        if name:
-            query_list.append(f"{urllib.parse.urlencode({'job_name': name})}")
 
         query_string = ""
         if len(query_list) > 0:
@@ -247,13 +245,15 @@ class SlurmRestClient(SlurmBaseClient):
             if isinstance(result, Exception):
                 raise SlurmError("Error fetching Slurm API data.") from result
             if result and "jobs" in result:
-                # Note: starting from API version v0.0.39 this filter can be set as query param
+                # Note: starting from API version v0.0.39 the "user_name" filter can be set as query param
+                # Note: starting from API version v0.0.45 the "job_name" filter can be set as query param
                 filtered_jobs = list(
                     filter(
                         lambda job: (
-                            allusers or job["user"] == username
-                            if "user" in job
-                            else job["user_name"] == username
+                            (allusers or job["user"] == username
+                                if "user" in job
+                                else job["user_name"] == username)
+                            and (name is None or job["name"] == name)
                         ),
                         result["jobs"],
                     )

--- a/src/lib/scheduler_clients/slurm/slurm_rest_client.py
+++ b/src/lib/scheduler_clients/slurm/slurm_rest_client.py
@@ -242,12 +242,16 @@ class SlurmRestClient(SlurmBaseClient):
         for result in results:
             if isinstance(result, Exception):
                 raise SlurmError("Error fetching Slurm API data.") from result
+
+            def matches(job):
+                job_user = job.get("user") or job.get("user_name")
+                return (allusers or job_user == username) and (
+                    name is None or job.get("name") == name
+                )
+
             if result and "jobs" in result:
                 # Note: starting from API version v0.0.39 the "user_name" filter can be set as query param
                 # Note: starting from API version v0.0.45 the "job_name" filter can be set as query param
-                def matches(job):
-                    job_user = job.get("user", job.get("user_name"))
-                    return (allusers or job_user == username) and (name is None or job.get("name") == name)
 
                 filtered_jobs = list(filter(matches, result["jobs"]))
 

--- a/src/lib/scheduler_clients/slurm/slurm_rest_client.py
+++ b/src/lib/scheduler_clients/slurm/slurm_rest_client.py
@@ -210,15 +210,23 @@ class SlurmRestClient(SlurmBaseClient):
         raise NotImplementedError("This method is not supported by the Slurm REST API")
 
     async def get_jobs(
-        self, username: str, jwt_token: str, allusers: bool = False, account: str = None
+        self, username: str, jwt_token: str, allusers: bool = False,
+        account: str = None, name: str = None
     ) -> List[SlurmJob] | None:
         client = await self.get_aiohttp_client()
         timeout = aiohttp.ClientTimeout(total=self.timeout)
         headers = _slurm_headers(username, jwt_token, self.username_claim)
 
-        query_string = (
-            f"?{urllib.parse.urlencode({'account': account})}" if account else ""
-        )
+        query_list = []
+        if account:
+            query_list.append(f"{urllib.parse.urlencode({'account': account})}")
+        if name:
+            query_list.append(f"{urllib.parse.urlencode({'job_name': name})}")
+
+        query_string = ""
+        if len(query_list) > 0:
+            query_string = f"?{"&".join(query_list)}"
+
         slurmdb_url = f"{self.api_url}/slurmdb/v{self.api_version}/jobs{query_string}"
         slurm_url = f"{self.api_url}/slurm/v{self.api_version}/jobs{query_string}"
 

--- a/src/lib/scheduler_clients/slurm/slurm_rest_client.py
+++ b/src/lib/scheduler_clients/slurm/slurm_rest_client.py
@@ -217,13 +217,11 @@ class SlurmRestClient(SlurmBaseClient):
         timeout = aiohttp.ClientTimeout(total=self.timeout)
         headers = _slurm_headers(username, jwt_token, self.username_claim)
 
-        query_list = []
+        query_params = {}
         if account:
-            query_list.append(f"{urllib.parse.urlencode({'account': account})}")
+            query_params["account"] = account
 
-        query_string = ""
-        if len(query_list) > 0:
-            query_string = f"?{"&".join(query_list)}"
+        query_string = f"?{urllib.parse.urlencode(query_params)}" if query_params else ""
 
         slurmdb_url = f"{self.api_url}/slurmdb/v{self.api_version}/jobs{query_string}"
         slurm_url = f"{self.api_url}/slurm/v{self.api_version}/jobs{query_string}"
@@ -247,17 +245,12 @@ class SlurmRestClient(SlurmBaseClient):
             if result and "jobs" in result:
                 # Note: starting from API version v0.0.39 the "user_name" filter can be set as query param
                 # Note: starting from API version v0.0.45 the "job_name" filter can be set as query param
-                filtered_jobs = list(
-                    filter(
-                        lambda job: (
-                            (allusers or job["user"] == username
-                                if "user" in job
-                                else job["user_name"] == username)
-                            and (name is None or job["name"] == name)
-                        ),
-                        result["jobs"],
-                    )
-                )
+                def matches(job):
+                    job_user = job.get("user", job.get("user_name"))
+                    return (allusers or job_user == username) and (name is None or job.get("name") == name)
+
+                filtered_jobs = list(filter(matches, result["jobs"]))
+
                 for job in filtered_jobs:
                     job_obj = SlurmJob.model_validate(job)
                     if job_obj.time.limit is not None:

--- a/src/lib/scheduler_clients/slurm/slurm_rest_client.py
+++ b/src/lib/scheduler_clients/slurm/slurm_rest_client.py
@@ -246,7 +246,7 @@ class SlurmRestClient(SlurmBaseClient):
             def matches(job):
                 job_user = job.get("user") or job.get("user_name")
                 return (allusers or job_user == username) and (
-                    name is None or job.get("name") == name
+                    not name or job.get("name") == name
                 )
 
             if result and "jobs" in result:

--- a/tests/compute_pbs_ssh_test.py
+++ b/tests/compute_pbs_ssh_test.py
@@ -113,6 +113,41 @@ async def test_get_jobs_allusers(
         assert response.json()["jobs"][2]["user"] == "firesrv"
 
 
+async def test_get_jobs_by_name(
+    client, ssh_client, mocked_ssh_qstat_allusers_output, pbs_cluster
+):
+    async with ssh_client.mocked_output(
+        [MockedCommand(**mocked_ssh_qstat_allusers_output)]
+    ):
+        response = client.get(
+            "/compute/{cluster_name}/jobs?allusers=true&name=hi_pbs".format(
+                cluster_name=pbs_cluster.name
+            )
+        )
+        assert response.status_code == 200
+        assert response.json() is not None
+
+        assert response.json()["jobs"][0]["user"] == "firesrv"
+        assert response.json()["jobs"][0]["name"] == "hi_pbs"
+
+
+async def test_get_jobs_by_name_not_ok(
+    client, ssh_client, mocked_ssh_qstat_allusers_output, pbs_cluster
+):
+    async with ssh_client.mocked_output(
+        [MockedCommand(**mocked_ssh_qstat_allusers_output)]
+    ):
+        response = client.get(
+            "/compute/{cluster_name}/jobs?allusers=true&name=doesntexist".format(
+                cluster_name=pbs_cluster.name
+            )
+        )
+        assert response.status_code == 200
+        assert response.json() is not None
+
+        assert len(response.json()["jobs"]) == 0
+
+
 async def test_get_job_metadata(
     client,
     ssh_client,

--- a/tests/compute_slurm_api_test.py
+++ b/tests/compute_slurm_api_test.py
@@ -48,10 +48,29 @@ def mocked_get_jobs_allusers_response():
 
 
 @pytest.fixture(scope="module")
+def mocked_get_jobs_by_name_response():
+    response_file = (
+        impresources.files(mocked_api_responses) / "slurm_get_jobs_by_name.json"
+    )
+    with response_file.open("r") as response:
+        return json.load(response)
+
+
+@pytest.fixture(scope="module")
 def mocked_get_jobs_allusers_from_db_response():
     response_file = (
         impresources.files(mocked_api_responses)
         / "slurm_get_allusers_jobs_from_db.json"
+    )
+    with response_file.open("r") as response:
+        return json.load(response)
+
+
+@pytest.fixture(scope="module")
+def mocked_get_jobs_by_name_from_db_response():
+    response_file = (
+        impresources.files(mocked_api_responses)
+        / "slurm_get_jobs_by_name_from_db.json"
     )
     with response_file.open("r") as response:
         return json.load(response)
@@ -252,6 +271,64 @@ async def test_get_jobs_allusers(
         jobs_result = GetJobResponse(**response.json())
         assert jobs_result.jobs[0].user == "fireuser"
         assert jobs_result.jobs[1].user == "firesrv"
+
+
+async def test_get_jobs_by_name(
+    client,
+    mocked_get_jobs_by_name_response,
+    mocked_get_jobs_by_name_from_db_response,
+    slurm_cluster_with_api_config,
+):
+    with aioresponses() as mocked:
+
+        mocked.get(
+            f"{slurm_cluster_with_api_config.scheduler.api_url}/slurmdb/v{slurm_cluster_with_api_config.scheduler.api_version}/jobs",
+            status=200,
+            body=json.dumps(mocked_get_jobs_by_name_from_db_response),
+        )
+        mocked.get(
+            f"{slurm_cluster_with_api_config.scheduler.api_url}/slurm/v{slurm_cluster_with_api_config.scheduler.api_version}/jobs",
+            status=200,
+            body=json.dumps(mocked_get_jobs_by_name_response),
+        )
+
+        response = client.get(
+            f"/compute/{slurm_cluster_with_api_config.name}/jobs?name=NameExists"
+        )
+        assert response.status_code == 200
+        assert response.json() is not None
+
+        jobs_result = GetJobResponse(**response.json())
+
+        assert jobs_result.jobs[0].user == "test-user"
+        assert jobs_result.jobs[0].name == "NameExists"
+
+
+async def test_get_jobs_by_name_not_ok(
+    client,
+    mocked_get_jobs_by_name_response,
+    mocked_get_jobs_by_name_from_db_response,
+    slurm_cluster_with_api_config,
+):
+    with aioresponses() as mocked:
+
+        mocked.get(
+            f"{slurm_cluster_with_api_config.scheduler.api_url}/slurmdb/v{slurm_cluster_with_api_config.scheduler.api_version}/jobs",
+            status=200,
+            body=json.dumps(mocked_get_jobs_by_name_from_db_response),
+        )
+        mocked.get(
+            f"{slurm_cluster_with_api_config.scheduler.api_url}/slurm/v{slurm_cluster_with_api_config.scheduler.api_version}/jobs",
+            status=200,
+            body=json.dumps(mocked_get_jobs_by_name_response),
+        )
+
+        response = client.get(
+            f"/compute/{slurm_cluster_with_api_config.name}/jobs?name=DontExist"
+        )
+
+        assert response.status_code == 200
+        assert len(response.json()["jobs"]) == 0
 
 
 def test_cancel_job(client, mocked_cancel_job_response, slurm_cluster_with_api_config):

--- a/tests/compute_slurm_ssh_test.py
+++ b/tests/compute_slurm_ssh_test.py
@@ -27,6 +27,7 @@ def mocked_ssh_sbatch_output_out_of_quota():
     with output_file.open("rb") as output:
         return json.load(output)
 
+
 @pytest.fixture(scope="module")
 def mocked_ssh_squeue_allusers_output():
     output_file = (
@@ -37,9 +38,45 @@ def mocked_ssh_squeue_allusers_output():
 
 
 @pytest.fixture(scope="module")
+def mocked_ssh_squeue_by_name_output():
+    output_file = (
+        impresources.files(mocked_ssh_outputs) / "ssh_squeue_name_command.json"
+    )
+    with output_file.open("rb") as output:
+        return json.load(output)
+
+
+@pytest.fixture(scope="module")
+def mocked_ssh_squeue_by_name_not_ok_output():
+    output_file = (
+        impresources.files(mocked_ssh_outputs) / "ssh_squeue_name_not_ok_command.json"
+    )
+    with output_file.open("rb") as output:
+        return json.load(output)
+
+
+@pytest.fixture(scope="module")
 def mocked_ssh_sacct_allusers_output():
     output_file = (
         impresources.files(mocked_ssh_outputs) / "ssh_sacct_allusers_command.json"
+    )
+    with output_file.open("rb") as output:
+        return json.load(output)
+
+
+@pytest.fixture(scope="module")
+def mocked_ssh_sacct_by_name_output():
+    output_file = (
+        impresources.files(mocked_ssh_outputs) / "ssh_sacct_name_command.json"
+    )
+    with output_file.open("rb") as output:
+        return json.load(output)
+
+
+@pytest.fixture(scope="module")
+def mocked_ssh_sacct_by_name_not_ok_output():
+    output_file = (
+        impresources.files(mocked_ssh_outputs) / "ssh_sacct_name_not_ok_command.json"
     )
     with output_file.open("rb") as output:
         return json.load(output)
@@ -145,7 +182,7 @@ async def test_submit_job_out_of_quota(
 
 async def test_get_job(
     client,
-    ssh_client,    
+    ssh_client,
     slurm_cluster_with_ssh_config,
 ):
 
@@ -179,6 +216,56 @@ async def test_get_jobs_allusers(
 
         assert response.json()["jobs"][0]["user"] == "fireuser"
         assert response.json()["jobs"][1]["user"] == "firesrv"
+
+
+async def test_get_jobs_by_name(
+    client,
+    ssh_client,
+    mocked_ssh_sacct_by_name_output,
+    mocked_ssh_squeue_by_name_output,
+    slurm_cluster_with_ssh_config,
+):
+    async with ssh_client.mocked_output(
+        [
+            MockedCommand(**mocked_ssh_sacct_by_name_output),
+            MockedCommand(**mocked_ssh_squeue_by_name_output),
+        ]
+    ):
+        response = client.get(
+            "/compute/{cluster_name}/jobs?name=NameExists".format(
+                cluster_name=slurm_cluster_with_ssh_config.name
+            )
+        )
+
+        assert response.status_code == 200
+        assert response.json() is not None
+
+        assert response.json()["jobs"][0]["name"] == "NameExists"
+        assert response.json()["jobs"][0]["user"] == "test-user"
+
+
+async def test_get_jobs_by_name_notok(
+    client,
+    ssh_client,
+    mocked_ssh_sacct_by_name_not_ok_output,
+    mocked_ssh_squeue_by_name_not_ok_output,
+    slurm_cluster_with_ssh_config,
+):
+    async with ssh_client.mocked_output(
+        [
+            MockedCommand(**mocked_ssh_sacct_by_name_not_ok_output),
+            MockedCommand(**mocked_ssh_squeue_by_name_not_ok_output),
+        ]
+    ):
+        response = client.get(
+            "/compute/{cluster_name}/jobs?name=DontExist".format(
+                cluster_name=slurm_cluster_with_ssh_config.name
+            )
+        )
+        assert response.status_code == 200
+        assert response.json() is not None
+
+        assert len(response.json()["jobs"]) == 0
 
 
 async def test_get_job_metadata(

--- a/tests/compute_slurm_ssh_test.py
+++ b/tests/compute_slurm_ssh_test.py
@@ -300,12 +300,12 @@ async def test_get_jobs_by_name_notok(
         ]
     ):
         response = client.get(
-            "/compute/{cluster_name}/jobs?name='x' ; touch /tmp/pwn ; ''".format(
+            "/compute/{cluster_name}/jobs?name='x' ; touch /tmp/test ; ''".format(
                 cluster_name=slurm_cluster_with_ssh_config.name
             )
         )
-        assert response.status_code == 400
-        assert response.json() is not None       
+        assert response.status_code == 200
+        assert response.json() is not None
 
 
 async def test_get_job_metadata(

--- a/tests/compute_slurm_ssh_test.py
+++ b/tests/compute_slurm_ssh_test.py
@@ -47,6 +47,15 @@ def mocked_ssh_squeue_by_name_output():
 
 
 @pytest.fixture(scope="module")
+def mocked_ssh_squeue_by_name_dont_exist_output():
+    output_file = (
+        impresources.files(mocked_ssh_outputs) / "ssh_squeue_name_dont_exist_command.json"
+    )
+    with output_file.open("rb") as output:
+        return json.load(output)
+
+
+@pytest.fixture(scope="module")
 def mocked_ssh_squeue_by_name_not_ok_output():
     output_file = (
         impresources.files(mocked_ssh_outputs) / "ssh_squeue_name_not_ok_command.json"
@@ -72,6 +81,15 @@ def mocked_ssh_sacct_by_name_output():
     with output_file.open("rb") as output:
         return json.load(output)
 
+
+@pytest.fixture(scope="module")
+def mocked_ssh_sacct_by_name_dont_exist_output():
+    output_file = (
+        impresources.files(mocked_ssh_outputs) / "ssh_sacct_name_dont_exist_command.json"
+    )
+    with output_file.open("rb") as output:
+        return json.load(output)
+    
 
 @pytest.fixture(scope="module")
 def mocked_ssh_sacct_by_name_not_ok_output():
@@ -244,6 +262,30 @@ async def test_get_jobs_by_name(
         assert response.json()["jobs"][0]["user"] == "test-user"
 
 
+async def test_get_jobs_by_name_dont_exist(
+    client,
+    ssh_client,
+    mocked_ssh_sacct_by_name_dont_exist_output,
+    mocked_ssh_squeue_by_name_dont_exist_output,
+    slurm_cluster_with_ssh_config,
+):
+    async with ssh_client.mocked_output(
+        [
+            MockedCommand(**mocked_ssh_sacct_by_name_dont_exist_output),
+            MockedCommand(**mocked_ssh_squeue_by_name_dont_exist_output),
+        ]
+    ):
+        response = client.get(
+            "/compute/{cluster_name}/jobs?name=DontExist".format(
+                cluster_name=slurm_cluster_with_ssh_config.name
+            )
+        )
+        assert response.status_code == 200
+        assert response.json() is not None
+
+        assert len(response.json()["jobs"]) == 0
+
+
 async def test_get_jobs_by_name_notok(
     client,
     ssh_client,
@@ -258,14 +300,12 @@ async def test_get_jobs_by_name_notok(
         ]
     ):
         response = client.get(
-            "/compute/{cluster_name}/jobs?name=DontExist".format(
+            "/compute/{cluster_name}/jobs?name='x' ; touch /tmp/pwn ; ''".format(
                 cluster_name=slurm_cluster_with_ssh_config.name
             )
         )
-        assert response.status_code == 200
-        assert response.json() is not None
-
-        assert len(response.json()["jobs"]) == 0
+        assert response.status_code == 400
+        assert response.json() is not None       
 
 
 async def test_get_job_metadata(

--- a/tests/mocked_api_responses/slurm_get_jobs_by_name.json
+++ b/tests/mocked_api_responses/slurm_get_jobs_by_name.json
@@ -1,0 +1,443 @@
+{
+    "jobs": [
+        {
+            "account": "staff",
+            "accrue_time": {
+                "set": true,
+                "infinite": false,
+                "number": 1787141488
+            },
+            "admin_comment": "",
+            "allocating_node": "slurm",
+            "array_job_id": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+            },
+            "array_task_id": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+            },
+            "array_max_tasks": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+            },
+            "array_task_string": "",
+            "association_id": 6,
+            "batch_features": "",
+            "batch_flag": true,
+            "batch_host": "localhost",
+            "flags": [
+                "USING_DEFAULT_ACCOUNT",
+                "USING_DEFAULT_PARTITION",
+                "USING_DEFAULT_QOS",
+                "USING_DEFAULT_WCKEY",
+                "PARTITION_ASSIGNED"
+            ],
+            "burst_buffer": "",
+            "burst_buffer_state": "",
+            "cluster": "cluster",
+            "cluster_features": "",
+            "command": "",
+            "comment": "",
+            "container": "",
+            "container_id": "",
+            "contiguous": false,
+            "core_spec": 0,
+            "thread_spec": 32766,
+            "cores_per_socket": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+            },
+            "billable_tres": {
+                "set": true,
+                "infinite": false,
+                "number": 1.0
+            },
+            "cpus_per_task": {
+                "set": true,
+                "infinite": false,
+                "number": 1
+            },
+            "cpu_frequency_minimum": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+            },
+            "cpu_frequency_maximum": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+            },
+            "cpu_frequency_governor": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+            },
+            "cpus_per_tres": "",
+            "cron": "",
+            "deadline": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+            },
+            "delay_boot": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+            },
+            "dependency": "",
+            "derived_exit_code": {
+                "status": [
+                    "SUCCESS"
+                ],
+                "return_code": {
+                    "set": true,
+                    "infinite": false,
+                    "number": 0
+                },
+                "signal": {
+                    "id": {
+                        "set": false,
+                        "infinite": false,
+                        "number": 0
+                    },
+                    "name": ""
+                }
+            },
+            "eligible_time": {
+                "set": true,
+                "infinite": false,
+                "number": 1787141488
+            },
+            "end_time": {
+                "set": true,
+                "infinite": false,
+                "number": 1787142131
+            },
+            "excluded_nodes": "",
+            "exit_code": {
+                "status": [
+                    "SUCCESS"
+                ],
+                "return_code": {
+                    "set": true,
+                    "infinite": false,
+                    "number": 0
+                },
+                "signal": {
+                    "id": {
+                        "set": false,
+                        "infinite": false,
+                        "number": 0
+                    },
+                    "name": ""
+                }
+            },
+            "extra": "",
+            "failed_node": "",
+            "features": "",
+            "federation_origin": "",
+            "federation_siblings_active": "",
+            "federation_siblings_viable": "",
+            "gres_detail": [],
+            "group_id": 100,
+            "group_name": "users",
+            "het_job_id": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+            },
+            "het_job_id_set": "",
+            "het_job_offset": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+            },
+            "job_id": 14,
+            "job_resources": {
+                "select_type": [
+                    "CPU"
+                ],
+                "nodes": {
+                    "count": 1,
+                    "select_type": [
+                        "ONE_ROW"
+                    ],
+                    "list": "localhost",
+                    "whole": false,
+                    "allocation": [
+                        {
+                            "index": 0,
+                            "name": "localhost",
+                            "cpus": {
+                                "count": 1,
+                                "used": 0
+                            },
+                            "memory": {
+                                "used": 0,
+                                "allocated": 1000
+                            },
+                            "sockets": [
+                                {
+                                    "index": 0,
+                                    "cores": [
+                                        {
+                                            "index": 0,
+                                            "status": [
+                                                "ALLOCATED"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "index": 1,
+                                    "cores": [
+                                        {
+                                            "index": 0,
+                                            "status": [
+                                                "UNALLOCATED"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "cpus": 1,
+                "threads_per_core": {
+                    "set": false,
+                    "infinite": false,
+                    "number": 0
+                }
+            },
+            "job_size_str": [],
+            "job_state": [
+                "COMPLETED"
+            ],
+            "last_sched_evaluation": {
+                "set": true,
+                "infinite": false,
+                "number": 1787141530
+            },
+            "licenses": "",
+            "mail_type": [],
+            "mail_user": "fireuser",
+            "max_cpus": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+            },
+            "max_nodes": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+            },
+            "mcs_label": "",
+            "memory_per_tres": "",
+            "name": "NameExists",
+            "network": "",
+            "nodes": "localhost",
+            "nice": 0,
+            "tasks_per_core": {
+                "set": false,
+                "infinite": true,
+                "number": 0
+            },
+            "tasks_per_tres": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+            },
+            "tasks_per_node": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+            },
+            "tasks_per_socket": {
+                "set": false,
+                "infinite": true,
+                "number": 0
+            },
+            "tasks_per_board": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+            },
+            "cpus": {
+                "set": true,
+                "infinite": false,
+                "number": 1
+            },
+            "node_count": {
+                "set": true,
+                "infinite": false,
+                "number": 1
+            },
+            "tasks": {
+                "set": true,
+                "infinite": false,
+                "number": 1
+            },
+            "partition": "part01",
+            "prefer": "",
+            "memory_per_cpu": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+            },
+            "memory_per_node": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+            },
+            "minimum_cpus_per_node": {
+                "set": true,
+                "infinite": false,
+                "number": 1
+            },
+            "minimum_tmp_disk_per_node": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+            },
+            "power": {
+                "flags": []
+            },
+            "preempt_time": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+            },
+            "preemptable_time": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+            },
+            "pre_sus_time": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+            },
+            "hold": false,
+            "priority": {
+                "set": true,
+                "infinite": false,
+                "number": 1
+            },
+            "priority_by_partition": [],
+            "profile": [
+                "NOT_SET"
+            ],
+            "qos": "normal",
+            "reboot": false,
+            "required_nodes": "",
+            "required_switches": 0,
+            "requeue": true,
+            "resize_time": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+            },
+            "restart_cnt": 0,
+            "resv_name": "",
+            "scheduled_nodes": "",
+            "selinux_context": "",
+            "shared": [],
+            "sockets_per_board": 0,
+            "sockets_per_node": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+            },
+            "start_time": {
+                "set": true,
+                "infinite": false,
+                "number": 1787141530
+            },
+            "state_description": "",
+            "state_reason": "None",
+            "standard_error": "/home/fireuser/slurm-14.out",
+            "standard_input": "/dev/null",
+            "standard_output": "/home/fireuser/slurm-14.out",
+            "submit_time": {
+                "set": true,
+                "infinite": false,
+                "number": 1787141488
+            },
+            "suspend_time": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+            },
+            "system_comment": "",
+            "time_limit": {
+                "set": true,
+                "infinite": false,
+                "number": 7200
+            },
+            "time_minimum": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+            },
+            "threads_per_core": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+            },
+            "tres_bind": "",
+            "tres_freq": "",
+            "tres_per_job": "",
+            "tres_per_node": "",
+            "tres_per_socket": "",
+            "tres_per_task": "",
+            "tres_req_str": "cpu=1,mem=1000M,node=1,billing=1",
+            "tres_alloc_str": "cpu=1,mem=1000M,node=1,billing=1",
+            "user_id": 1001,
+            "user_name": "test-user",
+            "maximum_switch_wait_time": 0,
+            "wckey": "",
+            "current_working_directory": "/home/test-user"
+        }
+    ],
+    "last_backfill": {
+        "set": true,
+        "infinite": false,
+        "number": 1787141518
+    },
+    "last_update": {
+        "set": true,
+        "infinite": false,
+        "number": 1787142230
+    },
+    "meta": {
+        "plugin": {
+            "type": "openapi/slurmctld",
+            "name": "Slurm OpenAPI slurmctld",
+            "data_parser": "data_parser/v0.0.42",
+            "accounting_storage": "accounting_storage/slurmdbd"
+        },
+        "client": {
+            "source": "[slurm]:42010(fd:9)",
+            "user": "root",
+            "group": "root"
+        },
+        "command": [],
+        "slurm": {
+            "version": {
+                "major": "24",
+                "micro": "3",
+                "minor": "11"
+            },
+            "release": "24.11.3",
+            "cluster": "cluster"
+        }
+    },
+    "errors": [],
+    "warnings": []
+}

--- a/tests/mocked_api_responses/slurm_get_jobs_by_name_from_db.json
+++ b/tests/mocked_api_responses/slurm_get_jobs_by_name_from_db.json
@@ -1,0 +1,1849 @@
+{
+    "jobs": [
+        {
+            "account": "users",
+            "comment": {
+                "administrator": "",
+                "job": "",
+                "system": ""
+            },
+            "allocation_nodes": 1,
+            "array": {
+                "job_id": 0,
+                "limits": {
+                    "max": {
+                        "running": {
+                            "tasks": 0
+                        }
+                    }
+                },
+                "task_id": {
+                    "set": false,
+                    "infinite": false,
+                    "number": 0
+                },
+                "task": ""
+            },
+            "association": {
+                "account": "users",
+                "cluster": "cluster",
+                "partition": "",
+                "user": "fireuser",
+                "id": 7
+            },
+            "block": "",
+            "cluster": "cluster",
+            "constraints": "",
+            "container": "",
+            "derived_exit_code": {
+                "status": [
+                    "SUCCESS"
+                ],
+                "return_code": {
+                    "set": true,
+                    "infinite": false,
+                    "number": 0
+                },
+                "signal": {
+                    "id": {
+                        "set": false,
+                        "infinite": false,
+                        "number": 0
+                    },
+                    "name": ""
+                }
+            },
+            "time": {
+                "elapsed": 61,
+                "eligible": 1787124673,
+                "end": 1787124734,
+                "planned": {
+                    "set": true,
+                    "infinite": false,
+                    "number": 0
+                },
+                "start": 1787124673,
+                "submission": 1787124673,
+                "suspended": 0,
+                "system": {
+                    "seconds": 0,
+                    "microseconds": 0
+                },
+                "limit": {
+                    "set": true,
+                    "infinite": false,
+                    "number": 7200
+                },
+                "total": {
+                    "seconds": 0,
+                    "microseconds": 0
+                },
+                "user": {
+                    "seconds": 0,
+                    "microseconds": 0
+                }
+            },
+            "exit_code": {
+                "status": [
+                    "SUCCESS"
+                ],
+                "return_code": {
+                    "set": true,
+                    "infinite": false,
+                    "number": 0
+                },
+                "signal": {
+                    "id": {
+                        "set": false,
+                        "infinite": false,
+                        "number": 0
+                    },
+                    "name": ""
+                }
+            },
+            "extra": "",
+            "failed_node": "",
+            "flags": [
+                "STARTED_ON_SCHEDULE",
+                "START_RECEIVED"
+            ],
+            "group": "users",
+            "het": {
+                "job_id": 0,
+                "job_offset": {
+                    "set": false,
+                    "infinite": false,
+                    "number": 0
+                }
+            },
+            "job_id": 10,
+            "name": "SbatchTestXYZ",
+            "licenses": "",
+            "mcs": {
+                "label": ""
+            },
+            "nodes": "localhost",
+            "partition": "part01",
+            "hold": false,
+            "priority": {
+                "set": true,
+                "infinite": false,
+                "number": 1
+            },
+            "qos": "normal",
+            "qosreq": "",
+            "required": {
+                "CPUs": 1,
+                "memory_per_cpu": {
+                    "set": false,
+                    "infinite": false,
+                    "number": 0
+                },
+                "memory_per_node": {
+                    "set": true,
+                    "infinite": false,
+                    "number": 0
+                }
+            },
+            "kill_request_user": "",
+            "restart_cnt": 0,
+            "reservation": {
+                "id": 0,
+                "name": ""
+            },
+            "script": "",
+            "stdin_expanded": "/dev/null",
+            "stdout_expanded": "/home/fireuser/slurm-10.out",
+            "stderr_expanded": "",
+            "stdout": "/home/fireuser/slurm-%j.out",
+            "stderr": "",
+            "stdin": "/dev/null",
+            "state": {
+                "current": [
+                    "COMPLETED"
+                ],
+                "reason": "None"
+            },
+            "steps": [
+                {
+                    "time": {
+                        "elapsed": 61,
+                        "end": {
+                            "set": true,
+                            "infinite": false,
+                            "number": 1787124734
+                        },
+                        "start": {
+                            "set": true,
+                            "infinite": false,
+                            "number": 1787124673
+                        },
+                        "suspended": 0,
+                        "system": {
+                            "seconds": 0,
+                            "microseconds": 0
+                        },
+                        "total": {
+                            "seconds": 0,
+                            "microseconds": 0
+                        },
+                        "user": {
+                            "seconds": 0,
+                            "microseconds": 0
+                        }
+                    },
+                    "exit_code": {
+                        "status": [
+                            "SUCCESS"
+                        ],
+                        "return_code": {
+                            "set": true,
+                            "infinite": false,
+                            "number": 0
+                        },
+                        "signal": {
+                            "id": {
+                                "set": false,
+                                "infinite": false,
+                                "number": 0
+                            },
+                            "name": ""
+                        }
+                    },
+                    "nodes": {
+                        "count": 1,
+                        "range": "localhost",
+                        "list": [
+                            "localhost"
+                        ]
+                    },
+                    "tasks": {
+                        "count": 1
+                    },
+                    "pid": "",
+                    "CPU": {
+                        "requested_frequency": {
+                            "min": {
+                                "set": true,
+                                "infinite": false,
+                                "number": 0
+                            },
+                            "max": {
+                                "set": true,
+                                "infinite": false,
+                                "number": 0
+                            }
+                        },
+                        "governor": "0"
+                    },
+                    "kill_request_user": "",
+                    "state": [
+                        "COMPLETED"
+                    ],
+                    "statistics": {
+                        "CPU": {
+                            "actual_frequency": 0
+                        },
+                        "energy": {
+                            "consumed": {
+                                "set": true,
+                                "infinite": false,
+                                "number": 0
+                            }
+                        }
+                    },
+                    "step": {
+                        "id": "10.batch",
+                        "name": "batch"
+                    },
+                    "task": {
+                        "distribution": "Unknown"
+                    },
+                    "tres": {
+                        "requested": {
+                            "max": [],
+                            "min": [],
+                            "average": [],
+                            "total": []
+                        },
+                        "consumed": {
+                            "max": [],
+                            "min": [],
+                            "average": [],
+                            "total": []
+                        },
+                        "allocated": [
+                            {
+                                "type": "cpu",
+                                "name": "",
+                                "id": 1,
+                                "count": 1
+                            },
+                            {
+                                "type": "mem",
+                                "name": "",
+                                "id": 2,
+                                "count": 1000
+                            },
+                            {
+                                "type": "node",
+                                "name": "",
+                                "id": 4,
+                                "count": 1
+                            }
+                        ]
+                    }
+                }
+            ],
+            "submit_line": "sbatch --export=ALL,PATH=/bin:/usr/bin/:/usr/local/bin/,VAR1=Value1,VAR2=\"value2,asdadas\" --chdir=/home/fireuser --account=users --job-name=SbatchTestXYZ",
+            "tres": {
+                "allocated": [
+                    {
+                        "type": "cpu",
+                        "name": "",
+                        "id": 1,
+                        "count": 1
+                    },
+                    {
+                        "type": "mem",
+                        "name": "",
+                        "id": 2,
+                        "count": 1000
+                    },
+                    {
+                        "type": "energy",
+                        "name": "",
+                        "id": 3,
+                        "count": -2
+                    },
+                    {
+                        "type": "node",
+                        "name": "",
+                        "id": 4,
+                        "count": 1
+                    },
+                    {
+                        "type": "billing",
+                        "name": "",
+                        "id": 5,
+                        "count": 1
+                    }
+                ],
+                "requested": [
+                    {
+                        "type": "cpu",
+                        "name": "",
+                        "id": 1,
+                        "count": 1
+                    },
+                    {
+                        "type": "mem",
+                        "name": "",
+                        "id": 2,
+                        "count": 1000
+                    },
+                    {
+                        "type": "node",
+                        "name": "",
+                        "id": 4,
+                        "count": 1
+                    },
+                    {
+                        "type": "billing",
+                        "name": "",
+                        "id": 5,
+                        "count": 1
+                    }
+                ]
+            },
+            "used_gres": "",
+            "user": "fireuser",
+            "wckey": {
+                "wckey": "",
+                "flags": []
+            },
+            "working_directory": "/home/fireuser"
+        },
+        {
+            "account": "users",
+            "comment": {
+                "administrator": "",
+                "job": "",
+                "system": ""
+            },
+            "allocation_nodes": 1,
+            "array": {
+                "job_id": 0,
+                "limits": {
+                    "max": {
+                        "running": {
+                            "tasks": 0
+                        }
+                    }
+                },
+                "task_id": {
+                    "set": false,
+                    "infinite": false,
+                    "number": 0
+                },
+                "task": ""
+            },
+            "association": {
+                "account": "users",
+                "cluster": "cluster",
+                "partition": "",
+                "user": "fireuser",
+                "id": 7
+            },
+            "block": "",
+            "cluster": "cluster",
+            "constraints": "",
+            "container": "",
+            "derived_exit_code": {
+                "status": [
+                    "SUCCESS"
+                ],
+                "return_code": {
+                    "set": true,
+                    "infinite": false,
+                    "number": 0
+                },
+                "signal": {
+                    "id": {
+                        "set": false,
+                        "infinite": false,
+                        "number": 0
+                    },
+                    "name": ""
+                }
+            },
+            "time": {
+                "elapsed": 60,
+                "eligible": 1787126671,
+                "end": 1787126732,
+                "planned": {
+                    "set": true,
+                    "infinite": false,
+                    "number": 1
+                },
+                "start": 1787126672,
+                "submission": 1787126671,
+                "suspended": 0,
+                "system": {
+                    "seconds": 0,
+                    "microseconds": 0
+                },
+                "limit": {
+                    "set": true,
+                    "infinite": false,
+                    "number": 7200
+                },
+                "total": {
+                    "seconds": 0,
+                    "microseconds": 0
+                },
+                "user": {
+                    "seconds": 0,
+                    "microseconds": 0
+                }
+            },
+            "exit_code": {
+                "status": [
+                    "SUCCESS"
+                ],
+                "return_code": {
+                    "set": true,
+                    "infinite": false,
+                    "number": 0
+                },
+                "signal": {
+                    "id": {
+                        "set": false,
+                        "infinite": false,
+                        "number": 0
+                    },
+                    "name": ""
+                }
+            },
+            "extra": "",
+            "failed_node": "",
+            "flags": [
+                "STARTED_ON_SCHEDULE",
+                "START_RECEIVED"
+            ],
+            "group": "users",
+            "het": {
+                "job_id": 0,
+                "job_offset": {
+                    "set": false,
+                    "infinite": false,
+                    "number": 0
+                }
+            },
+            "job_id": 11,
+            "name": "SbatchTestXYZ",
+            "licenses": "",
+            "mcs": {
+                "label": ""
+            },
+            "nodes": "localhost",
+            "partition": "part01",
+            "hold": false,
+            "priority": {
+                "set": true,
+                "infinite": false,
+                "number": 1
+            },
+            "qos": "normal",
+            "qosreq": "",
+            "required": {
+                "CPUs": 1,
+                "memory_per_cpu": {
+                    "set": false,
+                    "infinite": false,
+                    "number": 0
+                },
+                "memory_per_node": {
+                    "set": true,
+                    "infinite": false,
+                    "number": 0
+                }
+            },
+            "kill_request_user": "",
+            "restart_cnt": 0,
+            "reservation": {
+                "id": 0,
+                "name": ""
+            },
+            "script": "",
+            "stdin_expanded": "/dev/null",
+            "stdout_expanded": "/home/fireuser/slurm-11.out",
+            "stderr_expanded": "",
+            "stdout": "/home/fireuser/slurm-%j.out",
+            "stderr": "",
+            "stdin": "/dev/null",
+            "state": {
+                "current": [
+                    "COMPLETED"
+                ],
+                "reason": "None"
+            },
+            "steps": [
+                {
+                    "time": {
+                        "elapsed": 60,
+                        "end": {
+                            "set": true,
+                            "infinite": false,
+                            "number": 1787126732
+                        },
+                        "start": {
+                            "set": true,
+                            "infinite": false,
+                            "number": 1787126672
+                        },
+                        "suspended": 0,
+                        "system": {
+                            "seconds": 0,
+                            "microseconds": 0
+                        },
+                        "total": {
+                            "seconds": 0,
+                            "microseconds": 0
+                        },
+                        "user": {
+                            "seconds": 0,
+                            "microseconds": 0
+                        }
+                    },
+                    "exit_code": {
+                        "status": [
+                            "SUCCESS"
+                        ],
+                        "return_code": {
+                            "set": true,
+                            "infinite": false,
+                            "number": 0
+                        },
+                        "signal": {
+                            "id": {
+                                "set": false,
+                                "infinite": false,
+                                "number": 0
+                            },
+                            "name": ""
+                        }
+                    },
+                    "nodes": {
+                        "count": 1,
+                        "range": "localhost",
+                        "list": [
+                            "localhost"
+                        ]
+                    },
+                    "tasks": {
+                        "count": 1
+                    },
+                    "pid": "",
+                    "CPU": {
+                        "requested_frequency": {
+                            "min": {
+                                "set": true,
+                                "infinite": false,
+                                "number": 0
+                            },
+                            "max": {
+                                "set": true,
+                                "infinite": false,
+                                "number": 0
+                            }
+                        },
+                        "governor": "0"
+                    },
+                    "kill_request_user": "",
+                    "state": [
+                        "COMPLETED"
+                    ],
+                    "statistics": {
+                        "CPU": {
+                            "actual_frequency": 0
+                        },
+                        "energy": {
+                            "consumed": {
+                                "set": true,
+                                "infinite": false,
+                                "number": 0
+                            }
+                        }
+                    },
+                    "step": {
+                        "id": "11.batch",
+                        "name": "batch"
+                    },
+                    "task": {
+                        "distribution": "Unknown"
+                    },
+                    "tres": {
+                        "requested": {
+                            "max": [],
+                            "min": [],
+                            "average": [],
+                            "total": []
+                        },
+                        "consumed": {
+                            "max": [],
+                            "min": [],
+                            "average": [],
+                            "total": []
+                        },
+                        "allocated": [
+                            {
+                                "type": "cpu",
+                                "name": "",
+                                "id": 1,
+                                "count": 1
+                            },
+                            {
+                                "type": "mem",
+                                "name": "",
+                                "id": 2,
+                                "count": 1000
+                            },
+                            {
+                                "type": "node",
+                                "name": "",
+                                "id": 4,
+                                "count": 1
+                            }
+                        ]
+                    }
+                }
+            ],
+            "submit_line": "sbatch --export=ALL,PATH=/bin:/usr/bin/:/usr/local/bin/,VAR1=Value1,VAR2=\"value2,asdadas\" --chdir=/home/fireuser --account=users --job-name=SbatchTestXYZ",
+            "tres": {
+                "allocated": [
+                    {
+                        "type": "cpu",
+                        "name": "",
+                        "id": 1,
+                        "count": 1
+                    },
+                    {
+                        "type": "mem",
+                        "name": "",
+                        "id": 2,
+                        "count": 1000
+                    },
+                    {
+                        "type": "energy",
+                        "name": "",
+                        "id": 3,
+                        "count": -2
+                    },
+                    {
+                        "type": "node",
+                        "name": "",
+                        "id": 4,
+                        "count": 1
+                    },
+                    {
+                        "type": "billing",
+                        "name": "",
+                        "id": 5,
+                        "count": 1
+                    }
+                ],
+                "requested": [
+                    {
+                        "type": "cpu",
+                        "name": "",
+                        "id": 1,
+                        "count": 1
+                    },
+                    {
+                        "type": "mem",
+                        "name": "",
+                        "id": 2,
+                        "count": 1000
+                    },
+                    {
+                        "type": "node",
+                        "name": "",
+                        "id": 4,
+                        "count": 1
+                    },
+                    {
+                        "type": "billing",
+                        "name": "",
+                        "id": 5,
+                        "count": 1
+                    }
+                ]
+            },
+            "used_gres": "",
+            "user": "fireuser",
+            "wckey": {
+                "wckey": "",
+                "flags": []
+            },
+            "working_directory": "/home/fireuser"
+        },
+        {
+            "account": "users",
+            "comment": {
+                "administrator": "",
+                "job": "",
+                "system": ""
+            },
+            "allocation_nodes": 1,
+            "array": {
+                "job_id": 0,
+                "limits": {
+                    "max": {
+                        "running": {
+                            "tasks": 0
+                        }
+                    }
+                },
+                "task_id": {
+                    "set": false,
+                    "infinite": false,
+                    "number": 0
+                },
+                "task": ""
+            },
+            "association": {
+                "account": "users",
+                "cluster": "cluster",
+                "partition": "",
+                "user": "fireuser",
+                "id": 7
+            },
+            "block": "",
+            "cluster": "cluster",
+            "constraints": "",
+            "container": "",
+            "derived_exit_code": {
+                "status": [
+                    "SUCCESS"
+                ],
+                "return_code": {
+                    "set": true,
+                    "infinite": false,
+                    "number": 0
+                },
+                "signal": {
+                    "id": {
+                        "set": false,
+                        "infinite": false,
+                        "number": 0
+                    },
+                    "name": ""
+                }
+            },
+            "time": {
+                "elapsed": 61,
+                "eligible": 1787127431,
+                "end": 1787127492,
+                "planned": {
+                    "set": true,
+                    "infinite": false,
+                    "number": 0
+                },
+                "start": 1787127431,
+                "submission": 1787127431,
+                "suspended": 0,
+                "system": {
+                    "seconds": 0,
+                    "microseconds": 0
+                },
+                "limit": {
+                    "set": true,
+                    "infinite": false,
+                    "number": 7200
+                },
+                "total": {
+                    "seconds": 0,
+                    "microseconds": 0
+                },
+                "user": {
+                    "seconds": 0,
+                    "microseconds": 0
+                }
+            },
+            "exit_code": {
+                "status": [
+                    "SUCCESS"
+                ],
+                "return_code": {
+                    "set": true,
+                    "infinite": false,
+                    "number": 0
+                },
+                "signal": {
+                    "id": {
+                        "set": false,
+                        "infinite": false,
+                        "number": 0
+                    },
+                    "name": ""
+                }
+            },
+            "extra": "",
+            "failed_node": "",
+            "flags": [
+                "STARTED_ON_SCHEDULE",
+                "START_RECEIVED"
+            ],
+            "group": "users",
+            "het": {
+                "job_id": 0,
+                "job_offset": {
+                    "set": false,
+                    "infinite": false,
+                    "number": 0
+                }
+            },
+            "job_id": 12,
+            "name": "NameExists",
+            "licenses": "",
+            "mcs": {
+                "label": ""
+            },
+            "nodes": "localhost",
+            "partition": "part01",
+            "hold": false,
+            "priority": {
+                "set": true,
+                "infinite": false,
+                "number": 1
+            },
+            "qos": "normal",
+            "qosreq": "",
+            "required": {
+                "CPUs": 1,
+                "memory_per_cpu": {
+                    "set": false,
+                    "infinite": false,
+                    "number": 0
+                },
+                "memory_per_node": {
+                    "set": true,
+                    "infinite": false,
+                    "number": 0
+                }
+            },
+            "kill_request_user": "",
+            "restart_cnt": 0,
+            "reservation": {
+                "id": 0,
+                "name": ""
+            },
+            "script": "",
+            "stdin_expanded": "/dev/null",
+            "stdout_expanded": "/home/fireuser/slurm-12.out",
+            "stderr_expanded": "",
+            "stdout": "/home/fireuser/slurm-%j.out",
+            "stderr": "",
+            "stdin": "/dev/null",
+            "state": {
+                "current": [
+                    "COMPLETED"
+                ],
+                "reason": "None"
+            },
+            "steps": [
+                {
+                    "time": {
+                        "elapsed": 61,
+                        "end": {
+                            "set": true,
+                            "infinite": false,
+                            "number": 1787127492
+                        },
+                        "start": {
+                            "set": true,
+                            "infinite": false,
+                            "number": 1787127431
+                        },
+                        "suspended": 0,
+                        "system": {
+                            "seconds": 0,
+                            "microseconds": 0
+                        },
+                        "total": {
+                            "seconds": 0,
+                            "microseconds": 0
+                        },
+                        "user": {
+                            "seconds": 0,
+                            "microseconds": 0
+                        }
+                    },
+                    "exit_code": {
+                        "status": [
+                            "SUCCESS"
+                        ],
+                        "return_code": {
+                            "set": true,
+                            "infinite": false,
+                            "number": 0
+                        },
+                        "signal": {
+                            "id": {
+                                "set": false,
+                                "infinite": false,
+                                "number": 0
+                            },
+                            "name": ""
+                        }
+                    },
+                    "nodes": {
+                        "count": 1,
+                        "range": "localhost",
+                        "list": [
+                            "localhost"
+                        ]
+                    },
+                    "tasks": {
+                        "count": 1
+                    },
+                    "pid": "",
+                    "CPU": {
+                        "requested_frequency": {
+                            "min": {
+                                "set": true,
+                                "infinite": false,
+                                "number": 0
+                            },
+                            "max": {
+                                "set": true,
+                                "infinite": false,
+                                "number": 0
+                            }
+                        },
+                        "governor": "0"
+                    },
+                    "kill_request_user": "",
+                    "state": [
+                        "COMPLETED"
+                    ],
+                    "statistics": {
+                        "CPU": {
+                            "actual_frequency": 0
+                        },
+                        "energy": {
+                            "consumed": {
+                                "set": true,
+                                "infinite": false,
+                                "number": 0
+                            }
+                        }
+                    },
+                    "step": {
+                        "id": "12.batch",
+                        "name": "batch"
+                    },
+                    "task": {
+                        "distribution": "Unknown"
+                    },
+                    "tres": {
+                        "requested": {
+                            "max": [],
+                            "min": [],
+                            "average": [],
+                            "total": []
+                        },
+                        "consumed": {
+                            "max": [],
+                            "min": [],
+                            "average": [],
+                            "total": []
+                        },
+                        "allocated": [
+                            {
+                                "type": "cpu",
+                                "name": "",
+                                "id": 1,
+                                "count": 1
+                            },
+                            {
+                                "type": "mem",
+                                "name": "",
+                                "id": 2,
+                                "count": 1000
+                            },
+                            {
+                                "type": "node",
+                                "name": "",
+                                "id": 4,
+                                "count": 1
+                            }
+                        ]
+                    }
+                }
+            ],
+            "submit_line": "sbatch --export=ALL,PATH=/bin:/usr/bin/:/usr/local/bin/,VAR1=Value1,VAR2=\"value2,asdadas\" --chdir=/home/fireuser --account=users --job-name=NameExists",
+            "tres": {
+                "allocated": [
+                    {
+                        "type": "cpu",
+                        "name": "",
+                        "id": 1,
+                        "count": 1
+                    },
+                    {
+                        "type": "mem",
+                        "name": "",
+                        "id": 2,
+                        "count": 1000
+                    },
+                    {
+                        "type": "energy",
+                        "name": "",
+                        "id": 3,
+                        "count": -2
+                    },
+                    {
+                        "type": "node",
+                        "name": "",
+                        "id": 4,
+                        "count": 1
+                    },
+                    {
+                        "type": "billing",
+                        "name": "",
+                        "id": 5,
+                        "count": 1
+                    }
+                ],
+                "requested": [
+                    {
+                        "type": "cpu",
+                        "name": "",
+                        "id": 1,
+                        "count": 1
+                    },
+                    {
+                        "type": "mem",
+                        "name": "",
+                        "id": 2,
+                        "count": 1000
+                    },
+                    {
+                        "type": "node",
+                        "name": "",
+                        "id": 4,
+                        "count": 1
+                    },
+                    {
+                        "type": "billing",
+                        "name": "",
+                        "id": 5,
+                        "count": 1
+                    }
+                ]
+            },
+            "used_gres": "",
+            "user": "fireuser",
+            "wckey": {
+                "wckey": "",
+                "flags": []
+            },
+            "working_directory": "/home/fireuser"
+        },
+        {
+            "account": "staff",
+            "comment": {
+                "administrator": "",
+                "job": "",
+                "system": ""
+            },
+            "allocation_nodes": 1,
+            "array": {
+                "job_id": 0,
+                "limits": {
+                    "max": {
+                        "running": {
+                            "tasks": 0
+                        }
+                    }
+                },
+                "task_id": {
+                    "set": false,
+                    "infinite": false,
+                    "number": 0
+                },
+                "task": ""
+            },
+            "association": {
+                "account": "staff",
+                "cluster": "cluster",
+                "partition": "",
+                "user": "firesrv",
+                "id": 8
+            },
+            "block": "",
+            "cluster": "cluster",
+            "constraints": "",
+            "container": "",
+            "derived_exit_code": {
+                "status": [
+                    "SUCCESS"
+                ],
+                "return_code": {
+                    "set": true,
+                    "infinite": false,
+                    "number": 0
+                },
+                "signal": {
+                    "id": {
+                        "set": false,
+                        "infinite": false,
+                        "number": 0
+                    },
+                    "name": ""
+                }
+            },
+            "time": {
+                "elapsed": 130,
+                "eligible": 1787141399,
+                "end": 1787141529,
+                "planned": {
+                    "set": true,
+                    "infinite": false,
+                    "number": 0
+                },
+                "start": 1787141399,
+                "submission": 1787141399,
+                "suspended": 0,
+                "system": {
+                    "seconds": 0,
+                    "microseconds": 0
+                },
+                "limit": {
+                    "set": true,
+                    "infinite": false,
+                    "number": 7200
+                },
+                "total": {
+                    "seconds": 0,
+                    "microseconds": 0
+                },
+                "user": {
+                    "seconds": 0,
+                    "microseconds": 0
+                }
+            },
+            "exit_code": {
+                "status": [
+                    "SUCCESS"
+                ],
+                "return_code": {
+                    "set": true,
+                    "infinite": false,
+                    "number": 0
+                },
+                "signal": {
+                    "id": {
+                        "set": false,
+                        "infinite": false,
+                        "number": 0
+                    },
+                    "name": ""
+                }
+            },
+            "extra": "",
+            "failed_node": "",
+            "flags": [
+                "STARTED_ON_BACKFILL",
+                "START_RECEIVED"
+            ],
+            "group": "service-accounts",
+            "het": {
+                "job_id": 0,
+                "job_offset": {
+                    "set": false,
+                    "infinite": false,
+                    "number": 0
+                }
+            },
+            "job_id": 13,
+            "name": "wrap",
+            "licenses": "",
+            "mcs": {
+                "label": ""
+            },
+            "nodes": "localhost",
+            "partition": "part01",
+            "hold": false,
+            "priority": {
+                "set": true,
+                "infinite": false,
+                "number": 1
+            },
+            "qos": "normal",
+            "qosreq": "",
+            "required": {
+                "CPUs": 1,
+                "memory_per_cpu": {
+                    "set": false,
+                    "infinite": false,
+                    "number": 0
+                },
+                "memory_per_node": {
+                    "set": true,
+                    "infinite": false,
+                    "number": 0
+                }
+            },
+            "kill_request_user": "",
+            "restart_cnt": 0,
+            "reservation": {
+                "id": 0,
+                "name": ""
+            },
+            "script": "",
+            "stdin_expanded": "/dev/null",
+            "stdout_expanded": "/home/firesrv/slurm-13.out",
+            "stderr_expanded": "",
+            "stdout": "/home/firesrv/slurm-%j.out",
+            "stderr": "",
+            "stdin": "/dev/null",
+            "state": {
+                "current": [
+                    "COMPLETED"
+                ],
+                "reason": "None"
+            },
+            "steps": [
+                {
+                    "time": {
+                        "elapsed": 130,
+                        "end": {
+                            "set": true,
+                            "infinite": false,
+                            "number": 1787141529
+                        },
+                        "start": {
+                            "set": true,
+                            "infinite": false,
+                            "number": 1787141399
+                        },
+                        "suspended": 0,
+                        "system": {
+                            "seconds": 0,
+                            "microseconds": 0
+                        },
+                        "total": {
+                            "seconds": 0,
+                            "microseconds": 0
+                        },
+                        "user": {
+                            "seconds": 0,
+                            "microseconds": 0
+                        }
+                    },
+                    "exit_code": {
+                        "status": [
+                            "SUCCESS"
+                        ],
+                        "return_code": {
+                            "set": true,
+                            "infinite": false,
+                            "number": 0
+                        },
+                        "signal": {
+                            "id": {
+                                "set": false,
+                                "infinite": false,
+                                "number": 0
+                            },
+                            "name": ""
+                        }
+                    },
+                    "nodes": {
+                        "count": 1,
+                        "range": "localhost",
+                        "list": [
+                            "localhost"
+                        ]
+                    },
+                    "tasks": {
+                        "count": 1
+                    },
+                    "pid": "",
+                    "CPU": {
+                        "requested_frequency": {
+                            "min": {
+                                "set": true,
+                                "infinite": false,
+                                "number": 0
+                            },
+                            "max": {
+                                "set": true,
+                                "infinite": false,
+                                "number": 0
+                            }
+                        },
+                        "governor": "0"
+                    },
+                    "kill_request_user": "",
+                    "state": [
+                        "COMPLETED"
+                    ],
+                    "statistics": {
+                        "CPU": {
+                            "actual_frequency": 0
+                        },
+                        "energy": {
+                            "consumed": {
+                                "set": true,
+                                "infinite": false,
+                                "number": 0
+                            }
+                        }
+                    },
+                    "step": {
+                        "id": "13.batch",
+                        "name": "batch"
+                    },
+                    "task": {
+                        "distribution": "Unknown"
+                    },
+                    "tres": {
+                        "requested": {
+                            "max": [],
+                            "min": [],
+                            "average": [],
+                            "total": []
+                        },
+                        "consumed": {
+                            "max": [],
+                            "min": [],
+                            "average": [],
+                            "total": []
+                        },
+                        "allocated": [
+                            {
+                                "type": "cpu",
+                                "name": "",
+                                "id": 1,
+                                "count": 1
+                            },
+                            {
+                                "type": "mem",
+                                "name": "",
+                                "id": 2,
+                                "count": 1000
+                            },
+                            {
+                                "type": "node",
+                                "name": "",
+                                "id": 4,
+                                "count": 1
+                            }
+                        ]
+                    }
+                }
+            ],
+            "submit_line": "sbatch --wrap sleep 130s",
+            "tres": {
+                "allocated": [
+                    {
+                        "type": "cpu",
+                        "name": "",
+                        "id": 1,
+                        "count": 1
+                    },
+                    {
+                        "type": "mem",
+                        "name": "",
+                        "id": 2,
+                        "count": 1000
+                    },
+                    {
+                        "type": "energy",
+                        "name": "",
+                        "id": 3,
+                        "count": -2
+                    },
+                    {
+                        "type": "node",
+                        "name": "",
+                        "id": 4,
+                        "count": 1
+                    },
+                    {
+                        "type": "billing",
+                        "name": "",
+                        "id": 5,
+                        "count": 1
+                    }
+                ],
+                "requested": [
+                    {
+                        "type": "cpu",
+                        "name": "",
+                        "id": 1,
+                        "count": 1
+                    },
+                    {
+                        "type": "mem",
+                        "name": "",
+                        "id": 2,
+                        "count": 1000
+                    },
+                    {
+                        "type": "node",
+                        "name": "",
+                        "id": 4,
+                        "count": 1
+                    },
+                    {
+                        "type": "billing",
+                        "name": "",
+                        "id": 5,
+                        "count": 1
+                    }
+                ]
+            },
+            "used_gres": "",
+            "user": "firesrv",
+            "wckey": {
+                "wckey": "",
+                "flags": []
+            },
+            "working_directory": "/home/firesrv"
+        },
+        {
+            "account": "staff",
+            "comment": {
+                "administrator": "",
+                "job": "",
+                "system": ""
+            },
+            "allocation_nodes": 1,
+            "array": {
+                "job_id": 0,
+                "limits": {
+                    "max": {
+                        "running": {
+                            "tasks": 0
+                        }
+                    }
+                },
+                "task_id": {
+                    "set": false,
+                    "infinite": false,
+                    "number": 0
+                },
+                "task": ""
+            },
+            "association": {
+                "account": "staff",
+                "cluster": "cluster",
+                "partition": "",
+                "user": "fireuser",
+                "id": 6
+            },
+            "block": "",
+            "cluster": "cluster",
+            "constraints": "",
+            "container": "",
+            "derived_exit_code": {
+                "status": [
+                    "SUCCESS"
+                ],
+                "return_code": {
+                    "set": true,
+                    "infinite": false,
+                    "number": 0
+                },
+                "signal": {
+                    "id": {
+                        "set": false,
+                        "infinite": false,
+                        "number": 0
+                    },
+                    "name": ""
+                }
+            },
+            "time": {
+                "elapsed": 601,
+                "eligible": 1787141488,
+                "end": 1787142131,
+                "planned": {
+                    "set": true,
+                    "infinite": false,
+                    "number": 42
+                },
+                "start": 1787141530,
+                "submission": 1787141488,
+                "suspended": 0,
+                "system": {
+                    "seconds": 0,
+                    "microseconds": 0
+                },
+                "limit": {
+                    "set": true,
+                    "infinite": false,
+                    "number": 7200
+                },
+                "total": {
+                    "seconds": 0,
+                    "microseconds": 0
+                },
+                "user": {
+                    "seconds": 0,
+                    "microseconds": 0
+                }
+            },
+            "exit_code": {
+                "status": [
+                    "SUCCESS"
+                ],
+                "return_code": {
+                    "set": true,
+                    "infinite": false,
+                    "number": 0
+                },
+                "signal": {
+                    "id": {
+                        "set": false,
+                        "infinite": false,
+                        "number": 0
+                    },
+                    "name": ""
+                }
+            },
+            "extra": "",
+            "failed_node": "",
+            "flags": [
+                "STARTED_ON_SCHEDULE",
+                "START_RECEIVED"
+            ],
+            "group": "users",
+            "het": {
+                "job_id": 0,
+                "job_offset": {
+                    "set": false,
+                    "infinite": false,
+                    "number": 0
+                }
+            },
+            "job_id": 14,
+            "name": "wrap",
+            "licenses": "",
+            "mcs": {
+                "label": ""
+            },
+            "nodes": "localhost",
+            "partition": "part01",
+            "hold": false,
+            "priority": {
+                "set": true,
+                "infinite": false,
+                "number": 1
+            },
+            "qos": "normal",
+            "qosreq": "",
+            "required": {
+                "CPUs": 1,
+                "memory_per_cpu": {
+                    "set": false,
+                    "infinite": false,
+                    "number": 0
+                },
+                "memory_per_node": {
+                    "set": true,
+                    "infinite": false,
+                    "number": 0
+                }
+            },
+            "kill_request_user": "",
+            "restart_cnt": 0,
+            "reservation": {
+                "id": 0,
+                "name": ""
+            },
+            "script": "",
+            "stdin_expanded": "/dev/null",
+            "stdout_expanded": "/home/fireuser/slurm-14.out",
+            "stderr_expanded": "",
+            "stdout": "/home/fireuser/slurm-%j.out",
+            "stderr": "",
+            "stdin": "/dev/null",
+            "state": {
+                "current": [
+                    "COMPLETED"
+                ],
+                "reason": "None"
+            },
+            "steps": [
+                {
+                    "time": {
+                        "elapsed": 601,
+                        "end": {
+                            "set": true,
+                            "infinite": false,
+                            "number": 1787142131
+                        },
+                        "start": {
+                            "set": true,
+                            "infinite": false,
+                            "number": 1787141530
+                        },
+                        "suspended": 0,
+                        "system": {
+                            "seconds": 0,
+                            "microseconds": 0
+                        },
+                        "total": {
+                            "seconds": 0,
+                            "microseconds": 0
+                        },
+                        "user": {
+                            "seconds": 0,
+                            "microseconds": 0
+                        }
+                    },
+                    "exit_code": {
+                        "status": [
+                            "SUCCESS"
+                        ],
+                        "return_code": {
+                            "set": true,
+                            "infinite": false,
+                            "number": 0
+                        },
+                        "signal": {
+                            "id": {
+                                "set": false,
+                                "infinite": false,
+                                "number": 0
+                            },
+                            "name": ""
+                        }
+                    },
+                    "nodes": {
+                        "count": 1,
+                        "range": "localhost",
+                        "list": [
+                            "localhost"
+                        ]
+                    },
+                    "tasks": {
+                        "count": 1
+                    },
+                    "pid": "",
+                    "CPU": {
+                        "requested_frequency": {
+                            "min": {
+                                "set": true,
+                                "infinite": false,
+                                "number": 0
+                            },
+                            "max": {
+                                "set": true,
+                                "infinite": false,
+                                "number": 0
+                            }
+                        },
+                        "governor": "0"
+                    },
+                    "kill_request_user": "",
+                    "state": [
+                        "COMPLETED"
+                    ],
+                    "statistics": {
+                        "CPU": {
+                            "actual_frequency": 0
+                        },
+                        "energy": {
+                            "consumed": {
+                                "set": true,
+                                "infinite": false,
+                                "number": 0
+                            }
+                        }
+                    },
+                    "step": {
+                        "id": "14.batch",
+                        "name": "batch"
+                    },
+                    "task": {
+                        "distribution": "Unknown"
+                    },
+                    "tres": {
+                        "requested": {
+                            "max": [],
+                            "min": [],
+                            "average": [],
+                            "total": []
+                        },
+                        "consumed": {
+                            "max": [],
+                            "min": [],
+                            "average": [],
+                            "total": []
+                        },
+                        "allocated": [
+                            {
+                                "type": "cpu",
+                                "name": "",
+                                "id": 1,
+                                "count": 1
+                            },
+                            {
+                                "type": "mem",
+                                "name": "",
+                                "id": 2,
+                                "count": 1000
+                            },
+                            {
+                                "type": "node",
+                                "name": "",
+                                "id": 4,
+                                "count": 1
+                            }
+                        ]
+                    }
+                }
+            ],
+            "submit_line": "sbatch --wrap sleep 600s",
+            "tres": {
+                "allocated": [
+                    {
+                        "type": "cpu",
+                        "name": "",
+                        "id": 1,
+                        "count": 1
+                    },
+                    {
+                        "type": "mem",
+                        "name": "",
+                        "id": 2,
+                        "count": 1000
+                    },
+                    {
+                        "type": "energy",
+                        "name": "",
+                        "id": 3,
+                        "count": -2
+                    },
+                    {
+                        "type": "node",
+                        "name": "",
+                        "id": 4,
+                        "count": 1
+                    },
+                    {
+                        "type": "billing",
+                        "name": "",
+                        "id": 5,
+                        "count": 1
+                    }
+                ],
+                "requested": [
+                    {
+                        "type": "cpu",
+                        "name": "",
+                        "id": 1,
+                        "count": 1
+                    },
+                    {
+                        "type": "mem",
+                        "name": "",
+                        "id": 2,
+                        "count": 1000
+                    },
+                    {
+                        "type": "node",
+                        "name": "",
+                        "id": 4,
+                        "count": 1
+                    },
+                    {
+                        "type": "billing",
+                        "name": "",
+                        "id": 5,
+                        "count": 1
+                    }
+                ]
+            },
+            "used_gres": "",
+            "user": "fireuser",
+            "wckey": {
+                "wckey": "",
+                "flags": []
+            },
+            "working_directory": "/home/fireuser"
+        }
+    ],
+    "meta": {
+        "plugin": {
+            "type": "openapi/slurmdbd",
+            "name": "Slurm OpenAPI slurmdbd",
+            "data_parser": "data_parser/v0.0.42",
+            "accounting_storage": "accounting_storage/slurmdbd"
+        },
+        "client": {
+            "source": "[slurm]:42010(fd:11)",
+            "user": "",
+            "group": ""
+        },
+        "command": [],
+        "slurm": {
+            "version": {
+                "major": "24",
+                "micro": "3",
+                "minor": "11"
+            },
+            "release": "24.11.3",
+            "cluster": "cluster"
+        }
+    },
+    "errors": [],
+    "warnings": []
+}

--- a/tests/mocked_ssh_outputs/ssh_sacct_command.json
+++ b/tests/mocked_ssh_outputs/ssh_sacct_command.json
@@ -2,5 +2,5 @@
     "stdout": "1|1|cluster|0:0|users|staff|SbatchTest|localhost|part01|1|COMPLETED|None|100|1750232859|1750232859|1750232859|00:00:00|7200|fireuser|/home/fireuser",
     "stderr": "",
     "exit_code": 0,
-    "command":"sacct --allusers --jobs='1' --parsable2 --noheader --format='JobID,AllocNodes,Cluster,ExitCode,Group,Account,JobName,NodeList,Partition,Priority,State,Reason,ElapsedRaw,Submit,Start,End,Suspended,TimelimitRaw,User,WorkDir'"
+    "command":"sacct --allusers --jobs=1 --parsable2 --noheader --format='JobID,AllocNodes,Cluster,ExitCode,Group,Account,JobName,NodeList,Partition,Priority,State,Reason,ElapsedRaw,Submit,Start,End,Suspended,TimelimitRaw,User,WorkDir'"
 }

--- a/tests/mocked_ssh_outputs/ssh_sacct_name_command.json
+++ b/tests/mocked_ssh_outputs/ssh_sacct_name_command.json
@@ -1,0 +1,6 @@
+{
+    "stdout": "12|1|cluster|0:0|users|users|NameExists|localhost|part01|1|COMPLETED|None|61|1787127431|1787127431|1787127492|00:00:00|7200|test-user|/home/test-user\n12.batch|1|cluster|0:0||users|batch|localhost|||COMPLETED||61|1787127431|1787127431|1787127492|00:00:00|||",
+    "stderr": "",
+    "exit_code": 0,
+    "command":"SLURM_TIME_FORMAT='%s' sacct --name=NameExists --starttime=now-7days --parsable2 --noheader --format='JobID,AllocNodes,Cluster,ExitCode,Group,Account,JobName,NodeList,Partition,Priority,State,Reason,ElapsedRaw,Submit,Start,End,Suspended,TimelimitRaw,User,WorkDir'"
+}

--- a/tests/mocked_ssh_outputs/ssh_sacct_name_dont_exist_command.json
+++ b/tests/mocked_ssh_outputs/ssh_sacct_name_dont_exist_command.json
@@ -1,0 +1,6 @@
+{
+    "stdout": "JobID|JobName|Partition|Account|AllocCPUS|State|ExitCode",
+    "stderr": "",
+    "exit_code": 0,
+    "command": "SLURM_TIME_FORMAT='%s' sacct --name=DontExist --starttime=now-7days --parsable2 --noheader --format='JobID,AllocNodes,Cluster,ExitCode,Group,Account,JobName,NodeList,Partition,Priority,State,Reason,ElapsedRaw,Submit,Start,End,Suspended,TimelimitRaw,User,WorkDir'"
+}

--- a/tests/mocked_ssh_outputs/ssh_sacct_name_not_ok_command.json
+++ b/tests/mocked_ssh_outputs/ssh_sacct_name_not_ok_command.json
@@ -1,0 +1,6 @@
+{
+    "stdout": "JobID|JobName|Partition|Account|AllocCPUS|State|ExitCode",
+    "stderr": "",
+    "exit_code": 0,
+    "command": "SLURM_TIME_FORMAT='%s' sacct --name=DontExist --starttime=now-7days --parsable2 --noheader --format='JobID,AllocNodes,Cluster,ExitCode,Group,Account,JobName,NodeList,Partition,Priority,State,Reason,ElapsedRaw,Submit,Start,End,Suspended,TimelimitRaw,User,WorkDir'"
+}

--- a/tests/mocked_ssh_outputs/ssh_sacct_name_not_ok_command.json
+++ b/tests/mocked_ssh_outputs/ssh_sacct_name_not_ok_command.json
@@ -1,6 +1,6 @@
 {
-    "stdout": "JobID|JobName|Partition|Account|AllocCPUS|State|ExitCode",
+    "stdout": "JobID           JobName  Partition    Account  AllocCPUS      State ExitCode \n------------ ---------- ---------- ---------- ---------- ---------- -------- \n-bash: : command not found",
     "stderr": "",
     "exit_code": 0,
-    "command": "SLURM_TIME_FORMAT='%s' sacct --name=DontExist --starttime=now-7days --parsable2 --noheader --format='JobID,AllocNodes,Cluster,ExitCode,Group,Account,JobName,NodeList,Partition,Priority,State,Reason,ElapsedRaw,Submit,Start,End,Suspended,TimelimitRaw,User,WorkDir'"
+    "command": "SLURM_TIME_FORMAT='%s' sacct --name='x' ; touch /tmp/pwn ; '' --starttime=now-7days --parsable2 --noheader --format='JobID,AllocNodes,Cluster,ExitCode,Group,Account,JobName,NodeList,Partition,Priority,State,Reason,ElapsedRaw,Submit,Start,End,Suspended,TimelimitRaw,User,WorkDir'"
 }

--- a/tests/mocked_ssh_outputs/ssh_sacct_name_not_ok_command.json
+++ b/tests/mocked_ssh_outputs/ssh_sacct_name_not_ok_command.json
@@ -1,6 +1,6 @@
 {
-    "stdout": "JobID           JobName  Partition    Account  AllocCPUS      State ExitCode \n------------ ---------- ---------- ---------- ---------- ---------- -------- \n-bash: : command not found",
+    "stdout": "",
     "stderr": "",
     "exit_code": 0,
-    "command": "SLURM_TIME_FORMAT='%s' sacct --name='x' ; touch /tmp/pwn ; '' --starttime=now-7days --parsable2 --noheader --format='JobID,AllocNodes,Cluster,ExitCode,Group,Account,JobName,NodeList,Partition,Priority,State,Reason,ElapsedRaw,Submit,Start,End,Suspended,TimelimitRaw,User,WorkDir'"
+    "command": "SLURM_TIME_FORMAT='%s' sacct --name=''\"'\"'x'\"'\"' ; touch /tmp/test ; '\"'\"''\"'\"'' --starttime=now-7days --parsable2 --noheader --format='JobID,AllocNodes,Cluster,ExitCode,Group,Account,JobName,NodeList,Partition,Priority,State,Reason,ElapsedRaw,Submit,Start,End,Suspended,TimelimitRaw,User,WorkDir'"
 }

--- a/tests/mocked_ssh_outputs/ssh_squeue_command.json
+++ b/tests/mocked_ssh_outputs/ssh_squeue_command.json
@@ -1,6 +1,7 @@
 {
-    "stdout": "1|1|||users|staff|Count to 100||part01|0.00000000023283|PENDING|Resources|0:00|1773058665|N/A|(null)|5-00:00:00|fireuser|/home/fireuser",
+    "stdout": "1|1|cluster||users|users|SbatchTestXYZ|localhost|part01|1|RUNNING|None|0:07|1787124673|1787124673|1787556673||5-00:00:00|fireuser|/home/fireuser",
     "stderr": "",
     "exit_code": 0,
-    "command":"squeue --jobs='1' --noheader --Format='JobID:|,NumNodes:|,Cluster:||,GroupName:|,Account:|,Name:|,NodeList:|,Partition:|,PriorityLong:|,State:|,Reason:|,TimeUsed:|,SubmitTime:|,StartTime:|,EndTime:||,TimeLimit:|,UserName:|,WorkDir:'"
+    "command":"SLURM_TIME_FORMAT='%s' squeue --jobs=1 --noheader --Format='JobID:|,NumNodes:|,Cluster:||,GroupName:|,Account:|,Name:|,NodeList:|,Partition:|,PriorityLong:|,State:|,Reason:|,TimeUsed:|,SubmitTime:|,StartTime:|,EndTime:||,TimeLimit:|,UserName:|,WorkDir:'"
 }
+

--- a/tests/mocked_ssh_outputs/ssh_squeue_name_command.json
+++ b/tests/mocked_ssh_outputs/ssh_squeue_name_command.json
@@ -2,5 +2,5 @@
     "stdout": "12|1|cluster||users|users|NameExists|localhost|part01|1|RUNNING|None|0:11|1787127431|1787127431|1787559431||5-00:00:00|test-user|/home/test-user",
     "stderr": "",
     "exit_code": 0,
-    "command":"SLURM_TIME_FORMAT='%s' squeue --user='test-user' --name=NameExists --noheader --Format='JobID:|,NumNodes:|,Cluster:||,GroupName:|,Account:|,Name:|,NodeList:|,Partition:|,PriorityLong:|,State:|,Reason:|,TimeUsed:|,SubmitTime:|,StartTime:|,EndTime:||,TimeLimit:|,UserName:|,WorkDir:'"
+    "command":"SLURM_TIME_FORMAT='%s' squeue --user=test-user --name=NameExists --noheader --Format='JobID:|,NumNodes:|,Cluster:||,GroupName:|,Account:|,Name:|,NodeList:|,Partition:|,PriorityLong:|,State:|,Reason:|,TimeUsed:|,SubmitTime:|,StartTime:|,EndTime:||,TimeLimit:|,UserName:|,WorkDir:'"
 }

--- a/tests/mocked_ssh_outputs/ssh_squeue_name_command.json
+++ b/tests/mocked_ssh_outputs/ssh_squeue_name_command.json
@@ -1,0 +1,6 @@
+{
+    "stdout": "12|1|cluster||users|users|NameExists|localhost|part01|1|RUNNING|None|0:11|1787127431|1787127431|1787559431||5-00:00:00|test-user|/home/test-user",
+    "stderr": "",
+    "exit_code": 0,
+    "command":"SLURM_TIME_FORMAT='%s' squeue --user='test-user' --name=NameExists --noheader --Format='JobID:|,NumNodes:|,Cluster:||,GroupName:|,Account:|,Name:|,NodeList:|,Partition:|,PriorityLong:|,State:|,Reason:|,TimeUsed:|,SubmitTime:|,StartTime:|,EndTime:||,TimeLimit:|,UserName:|,WorkDir:'"
+}

--- a/tests/mocked_ssh_outputs/ssh_squeue_name_dont_exist_command.json
+++ b/tests/mocked_ssh_outputs/ssh_squeue_name_dont_exist_command.json
@@ -1,0 +1,7 @@
+{
+    "stdout": "",
+    "stderr": "",
+    "exit_code": 0,
+    "command":"SLURM_TIME_FORMAT='%s' squeue --user=test-user --name=DontExist --noheader --Format='JobID:|,NumNodes:|,Cluster:||,GroupName:|,Account:|,Name:|,NodeList:|,Partition:|,PriorityLong:|,State:|,Reason:|,TimeUsed:|,SubmitTime:|,StartTime:|,EndTime:||,TimeLimit:|,UserName:|,WorkDir:'"
+}
+

--- a/tests/mocked_ssh_outputs/ssh_squeue_name_not_ok_command.json
+++ b/tests/mocked_ssh_outputs/ssh_squeue_name_not_ok_command.json
@@ -1,0 +1,7 @@
+{
+    "stdout": "",
+    "stderr": "",
+    "exit_code": 0,
+    "command":"SLURM_TIME_FORMAT='%s' squeue --user='test-user' --name=DontExist --noheader --Format='JobID:|,NumNodes:|,Cluster:||,GroupName:|,Account:|,Name:|,NodeList:|,Partition:|,PriorityLong:|,State:|,Reason:|,TimeUsed:|,SubmitTime:|,StartTime:|,EndTime:||,TimeLimit:|,UserName:|,WorkDir:'"
+}
+

--- a/tests/mocked_ssh_outputs/ssh_squeue_name_not_ok_command.json
+++ b/tests/mocked_ssh_outputs/ssh_squeue_name_not_ok_command.json
@@ -1,7 +1,7 @@
 {
-    "stdout": "",
+    "stdout": "JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)\n-bash: : command not found",
     "stderr": "",
     "exit_code": 0,
-    "command":"SLURM_TIME_FORMAT='%s' squeue --user='test-user' --name=DontExist --noheader --Format='JobID:|,NumNodes:|,Cluster:||,GroupName:|,Account:|,Name:|,NodeList:|,Partition:|,PriorityLong:|,State:|,Reason:|,TimeUsed:|,SubmitTime:|,StartTime:|,EndTime:||,TimeLimit:|,UserName:|,WorkDir:'"
+    "command":"SLURM_TIME_FORMAT='%s' squeue --user=test-user --name=--name='x' ; touch /tmp/pwn ; '' --noheader --Format='JobID:|,NumNodes:|,Cluster:||,GroupName:|,Account:|,Name:|,NodeList:|,Partition:|,PriorityLong:|,State:|,Reason:|,TimeUsed:|,SubmitTime:|,StartTime:|,EndTime:||,TimeLimit:|,UserName:|,WorkDir:'"
 }
 

--- a/tests/mocked_ssh_outputs/ssh_squeue_name_not_ok_command.json
+++ b/tests/mocked_ssh_outputs/ssh_squeue_name_not_ok_command.json
@@ -1,7 +1,6 @@
 {
-    "stdout": "JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)\n-bash: : command not found",
+    "stdout": "",
     "stderr": "",
     "exit_code": 0,
-    "command":"SLURM_TIME_FORMAT='%s' squeue --user=test-user --name=--name='x' ; touch /tmp/pwn ; '' --noheader --Format='JobID:|,NumNodes:|,Cluster:||,GroupName:|,Account:|,Name:|,NodeList:|,Partition:|,PriorityLong:|,State:|,Reason:|,TimeUsed:|,SubmitTime:|,StartTime:|,EndTime:||,TimeLimit:|,UserName:|,WorkDir:'"
+    "command":"SLURM_TIME_FORMAT='%s' squeue --user=test-user --name=''\"'\"'x'\"'\"' ; touch /tmp/test ; '\"'\"''\"'\"'' --noheader --Format='JobID:|,NumNodes:|,Cluster:||,GroupName:|,Account:|,Name:|,NodeList:|,Partition:|,PriorityLong:|,State:|,Reason:|,TimeUsed:|,SubmitTime:|,StartTime:|,EndTime:||,TimeLimit:|,UserName:|,WorkDir:'"
 }
-


### PR DESCRIPTION
Adds the `name` parameter to the `GET /compute/jobs` request.

This PR fixes #223 